### PR TITLE
Rework the schema as discussed.

### DIFF
--- a/src/pytest_workflow/plugin.py
+++ b/src/pytest_workflow/plugin.py
@@ -75,8 +75,7 @@ class WorkflowTestsCollector(pytest.Collector):
         # Create a temporary directory where the workflow is run.
         # This will prevent the project repository from getting filled up with
         # test workflow output.
-        tempdir = tempfile.mkdtemp(
-            prefix="pytest_wf")
+        tempdir = tempfile.mkdtemp(prefix="pytest_wf")
 
         # Copy the project directory to the temporary directory. os.getcwd()
         # is used here because it is assumed pytest is run from project root.

--- a/src/pytest_workflow/plugin.py
+++ b/src/pytest_workflow/plugin.py
@@ -19,12 +19,12 @@
 import os
 import tempfile
 from distutils.dir_util import copy_tree
-from typing import Union
 
 import pytest
+
 import yaml
 
-from .schema import validate_schema, WorkflowTest
+from .schema import WorkflowTest, validate_schema
 from .workflow import Workflow
 from .workflow_file_tests import WorkflowFilesTestCollector
 
@@ -76,7 +76,7 @@ class WorkflowTestsCollector(pytest.Collector):
         # This will prevent the project repository from getting filled up with
         # test workflow output.
         tempdir = tempfile.mkdtemp(
-            prefix="pytest_wf")  # type: Union[bytes, str]
+            prefix="pytest_wf")
 
         # Copy the project directory to the temporary directory. os.getcwd()
         # is used here because it is assumed pytest is run from project root.

--- a/src/pytest_workflow/plugin.py
+++ b/src/pytest_workflow/plugin.py
@@ -24,7 +24,7 @@ import pytest
 
 import yaml
 
-from .schema import WorkflowTest, validate_schema
+from .schema import WorkflowTest, workflow_tests_from_schema
 from .workflow import Workflow
 from .workflow_file_tests import WorkflowFilesTestCollector
 
@@ -53,9 +53,9 @@ class YamlFile(pytest.File):
             tests in one yaml. """
         with self.fspath.open() as yaml_file:
             schema = yaml.safe_load(yaml_file)
-        validate_schema(schema)
-        for test in schema:
-            yield WorkflowTestsCollector(WorkflowTest.from_schema(test), self)
+        workflow_tests = workflow_tests_from_schema(schema)
+        for test in workflow_tests:
+            yield WorkflowTestsCollector(test, self)
 
 
 class WorkflowTestsCollector(pytest.Collector):

--- a/src/pytest_workflow/schema.py
+++ b/src/pytest_workflow/schema.py
@@ -26,11 +26,12 @@ with SCHEMA.open() as schema:
     JSON_SCHEMA = json.load(schema)
 
 
-def validate_schema(instance: dict):
+def validate_schema(instance):
     """
     Validates the pytest-workflow schema
-    :param instance: a dictionary that is validated against the schema
+    :param instance: an object that is validated against the schema
     :return: This function rasises a ValidationError
     when the schema is not correct.
     """
     jsonschema.validate(instance, JSON_SCHEMA)
+

--- a/src/pytest_workflow/schema.py
+++ b/src/pytest_workflow/schema.py
@@ -106,7 +106,6 @@ class FileTest(ContentTest):
         in the file
         """
         super().__init__(contains=contains, must_not_contain=must_not_contain)
-        self.path_as_string = path
         self.path = Path(path)
         self.md5sum = md5sum
         self.should_exist = should_exist

--- a/src/pytest_workflow/schema.py
+++ b/src/pytest_workflow/schema.py
@@ -71,8 +71,8 @@ class ContentTest(object):
     Everything in `must_not_contain` should not be present.
     """
 
-    def __init__(self, contains: List[str] = None,
-                 must_not_contain: List[str] = None):
+    def __init__(self, contains: Optional[List[str]] = None,
+                 must_not_contain: Optional[List[str]] = None):
         if contains:
             self.contains = contains
         else:
@@ -94,8 +94,8 @@ class FileTest(ContentTest):
     """A class that contains all the properties of a to be tested file."""
     def __init__(self, path: str, md5sum: Optional[str] = None,
                  should_exist: bool = DEFAULT_FILE_SHOULD_EXIST,
-                 contains: List[str] = None,
-                 must_not_contain: List[str] = None):
+                 contains: Optional[List[str]] = None,
+                 must_not_contain: Optional[List[str]] = None):
         """
         A container object
         :param path: the path to the file
@@ -135,7 +135,7 @@ class WorkflowTest(object):
                  exit_code: int = DEFAULT_EXIT_CODE,
                  stdout: ContentTest = ContentTest(),
                  stderr: ContentTest = ContentTest(),
-                 files: List[FileTest] = None):
+                 files: Optional[List[FileTest]] = None):
         """
         Create a WorkflowTest object.
         :param name: The name of the test

--- a/src/pytest_workflow/schema.py
+++ b/src/pytest_workflow/schema.py
@@ -18,7 +18,7 @@
 
 import json
 from pathlib import Path
-from typing import NamedTuple, NewType, List, Type
+from typing import NamedTuple, NewType, List, Type, Optional
 
 import jsonschema
 
@@ -41,20 +41,22 @@ def validate_schema(instance):
 
 ####### Schema classes below
 ####### These should be dataclasses. But that's not supported in python<3.7
-class StdOutErr(NamedTuple):
+class ContentCheck(NamedTuple):
     def __init__(self, contains: List[str] = [],
                  must_not_contain: List[str] = []):
         pass
 
 
-class FileTest(NamedTuple):
-    def __init__(self):
+class FileTest(ContentCheck):
+    def __init__(self, path: str, md5sum: Optional[str] = None,
+                 contains: List[str] = [], must_not_contain: List[str] = []):
+        super.__init__(contains=contains, must_not_contain=must_not_contain)
         pass
 
 
 class WorkflowTest(NamedTuple):
     def __init__(self, name: str, command: str, exit_code: int = 0,
-                 stdout: Type[StdOutErr] = StdOutErr(),
-                 stderr: Type[StdOutErr] = StdOutErr(),
+                 stdout: Type[ContentCheck] = ContentCheck(),
+                 stderr: Type[ContentCheck] = ContentCheck(),
                  files: List[Type[FileTest]] = []):
         pass

--- a/src/pytest_workflow/schema.py
+++ b/src/pytest_workflow/schema.py
@@ -158,10 +158,7 @@ class WorkflowTest(object):
     def from_schema(cls, schema: dict):
         """Generate a WorkflowTest object from schema objects"""
         test_file_dicts = schema.get("files", [])
-
-        test_files = []
-        for test_file_dict in test_file_dicts:
-            test_files.append(FileTest.from_dict(test_file_dict))
+        test_files = [FileTest.from_dict(x) for x in test_file_dicts]
 
         return cls(
             name=schema["name"],

--- a/src/pytest_workflow/schema.py
+++ b/src/pytest_workflow/schema.py
@@ -18,10 +18,13 @@
 
 import json
 from pathlib import Path
+from typing import NamedTuple, NewType, List, Type
 
 import jsonschema
 
 SCHEMA = Path(__file__).parent / Path("schema") / Path("schema.json")
+DEFAULT_EXIT_CODE = 0
+DEFAULT_FILES = []
 with SCHEMA.open() as schema:
     JSON_SCHEMA = json.load(schema)
 
@@ -35,3 +38,23 @@ def validate_schema(instance):
     """
     jsonschema.validate(instance, JSON_SCHEMA)
 
+
+####### Schema classes below
+####### These should be dataclasses. But that's not supported in python<3.7
+class StdOutErr(NamedTuple):
+    def __init__(self, contains: List[str] = [],
+                 must_not_contain: List[str] = []):
+        pass
+
+
+class FileTest(NamedTuple):
+    def __init__(self):
+        pass
+
+
+class WorkflowTest(NamedTuple):
+    def __init__(self, name: str, command: str, exit_code: int = 0,
+                 stdout: Type[StdOutErr] = StdOutErr(),
+                 stderr: Type[StdOutErr] = StdOutErr(),
+                 files: List[Type[FileTest]] = []):
+        pass

--- a/src/pytest_workflow/schema.py
+++ b/src/pytest_workflow/schema.py
@@ -39,24 +39,40 @@ def validate_schema(instance):
     jsonschema.validate(instance, JSON_SCHEMA)
 
 
-####### Schema classes below
-####### These should be dataclasses. But that's not supported in python<3.7
+# Schema classes below
+# These should be dataclasses. But that's not supported in python<3.7
+# These classes are created so that the test yaml does not have to be passed
+# around between test objects. But instead these objects which have self-
+# documenting members
+
 class ContentCheck(NamedTuple):
+    """
+    A class that holds two lists of strings. Everything in `contains` should be
+    present in the file/text
+    Everything in `must_not_contain` should not be present.
+    """
     def __init__(self, contains: List[str] = [],
                  must_not_contain: List[str] = []):
-        pass
+        self.contains = contains
+        self.must_not_contain = must_not_contain
 
 
 class FileTest(ContentCheck):
     def __init__(self, path: str, md5sum: Optional[str] = None,
                  contains: List[str] = [], must_not_contain: List[str] = []):
         super.__init__(contains=contains, must_not_contain=must_not_contain)
-        pass
-
+        self.path_as_string = path
+        self.path = Path(path)
+        self.md5sum = md5sum
 
 class WorkflowTest(NamedTuple):
     def __init__(self, name: str, command: str, exit_code: int = 0,
                  stdout: Type[ContentCheck] = ContentCheck(),
                  stderr: Type[ContentCheck] = ContentCheck(),
                  files: List[Type[FileTest]] = []):
-        pass
+        self.name = name
+        self.command = command
+        self.exit_code = exit_code
+        self.stdout = stdout
+        self.stderr = stderr
+        self.files = files

--- a/src/pytest_workflow/schema/schema.json
+++ b/src/pytest_workflow/schema/schema.json
@@ -12,7 +12,7 @@
       },
       "exit_code": {
         "description": "The expected exit code",
-        "type": "int"
+        "type": "number"
       },
       "files": {
         "description": "files produced by the workflow",
@@ -31,11 +31,11 @@
           "required": [
             "path"
           ]
-            }
-          }
         }
+      }
     },
     "required": [
       "command"
     ]
+  }
 }

--- a/src/pytest_workflow/schema/schema.json
+++ b/src/pytest_workflow/schema/schema.json
@@ -6,6 +6,10 @@
   "items": {
     "type": "object",
     "properties": {
+      "name": {
+        "description": "Name of the test",
+        "type": "string"
+      },
       "command": {
         "description": "The command that is run for the workflow",
         "type": "string"
@@ -13,6 +17,42 @@
       "exit_code": {
         "description": "The expected exit code",
         "type": "number"
+      },
+      "stderr": {
+        "type": "object",
+        "properties": {
+          "contains": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "must_not_contain": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "stdout": {
+        "type": "object",
+        "properties": {
+          "contains": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "must_not_contain": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "additionalProperties": false
       },
       "files": {
         "description": "files produced by the workflow",
@@ -26,16 +66,34 @@
             "md5sum": {
               "type": "string",
               "pattern": "^[a-f0-9]{32}$"
+            },
+            "should_exist": {
+              "type": "boolean"
+            },
+            "contains": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "must_not_contain": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             }
           },
           "required": [
             "path"
-          ]
+          ],
+          "additionalProperties": false
         }
       }
     },
     "required": [
+      "name",
       "command"
-    ]
+    ],
+    "additionalProperties": false
   }
 }

--- a/src/pytest_workflow/schema/schema.json
+++ b/src/pytest_workflow/schema/schema.json
@@ -1,43 +1,41 @@
 {
   "$schema": "https://json-schema.org/draft-07/schema",
   "title": "pytest-workflow YAML",
-  "description": "A YAML file describing a test for the pytest-workflow plugin",
-  "type": "object",
-  "properties": {
-    "arguments": {
-      "description": "arguments for the executable",
-      "type": "array",
-      "items": {
+  "description": "A YAML file describing tests for the pytest-workflow plugin",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "properties": {
+      "command": {
+        "description": "The command that is run for the workflow",
         "type": "string"
-      }
-    },
-    "executable": {
-      "description": "The executable that is being run",
-      "type": "string"
-    },
-    "results": {
-      "description": "A dictionary containing the results",
-      "type": "object",
-      "properties": {
-        "files": {
-          "description": "files produced by the workflow",
-          "type": "array",
-          "items": {
-            "type":"object",
-            "properties": {
-              "path": {
-                "type": "string"
-              },
-              "md5sum": {
-                "type": "string",
-                "pattern": "^[a-f0-9]{32}$"
-              }
+      },
+      "exit_code": {
+        "description": "The expected exit code",
+        "type": "int"
+      },
+      "files": {
+        "description": "files produced by the workflow",
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "path": {
+              "type": "string"
             },
-            "required": ["path"]
+            "md5sum": {
+              "type": "string",
+              "pattern": "^[a-f0-9]{32}$"
+            }
+          },
+          "required": [
+            "path"
+          ]
+            }
           }
         }
-      }
-    }
-  },
-  "required": ["executable","arguments", "results"]
+    },
+    "required": [
+      "command"
+    ]
 }

--- a/src/pytest_workflow/workflow.py
+++ b/src/pytest_workflow/workflow.py
@@ -1,32 +1,27 @@
 """This file was created by A.H.B. Bollen as a proof of concept."""
+import shlex
 import subprocess
-from pathlib import Path
-from typing import List, Union
+from typing import Union
 
 
 class Workflow(object):
 
-    def __init__(self, executable: Path, arguments: List[str],
+    def __init__(self, command: str,
                  cwd: Union[bytes, str] = None):
         """
         Initiates a workflow object
-        :param executable: The executable, such as `snakemake` `/bin/make`
-        or `cromwell`
-        :param arguments: The arguments passed to the executable. Such as
-        `-i inputs.json my_workflow.wdl`
+        :param command: The string that represents the command to be run
         :param cwd: The current working directory in which the command will
         be executed.
         """
 
-        self.executable = executable
-        # TODO: a pre-test to make sure the executable even exists
-        self.arguments = arguments
-
+        self.command = command
         self._proc_out = None
         self.cwd = cwd
 
     def run(self):
-        sub_procces_args = [str(self.executable)] + self.arguments
+        arguments = shlex.split(self.command)
+        sub_procces_args = arguments
         self._proc_out = subprocess.run(
             sub_procces_args, stdout=subprocess.PIPE,
             stderr=subprocess.PIPE, cwd=self.cwd)
@@ -42,12 +37,3 @@ class Workflow(object):
     @property
     def exit_code(self):
         return self._proc_out.returncode
-
-    @classmethod
-    def from_yaml_content(cls, yaml_contents: dict,
-                          cwd: Union[bytes, str] = None):
-        return cls(
-            Path(yaml_contents['executable']),
-            yaml_contents['arguments'],
-            cwd=cwd
-        )

--- a/src/pytest_workflow/workflow.py
+++ b/src/pytest_workflow/workflow.py
@@ -20,8 +20,7 @@ class Workflow(object):
         self.cwd = cwd
 
     def run(self):
-        arguments = shlex.split(self.command)
-        sub_procces_args = arguments
+        sub_procces_args = shlex.split(self.command)
         self._proc_out = subprocess.run(
             sub_procces_args, stdout=subprocess.PIPE,
             stderr=subprocess.PIPE, cwd=self.cwd)

--- a/src/pytest_workflow/workflow_file_tests.py
+++ b/src/pytest_workflow/workflow_file_tests.py
@@ -3,9 +3,9 @@
 from pathlib import Path
 from typing import List, Union
 
-from .schema import FileTest
-
 import pytest
+
+from .schema import FileTest
 
 
 class WorkflowFilesTestCollector(pytest.Collector):

--- a/src/pytest_workflow/workflow_file_tests.py
+++ b/src/pytest_workflow/workflow_file_tests.py
@@ -3,30 +3,33 @@
 from pathlib import Path
 from typing import List, Union
 
+from .schema import FileTest
+
 import pytest
 
 
 class WorkflowFilesTestCollector(pytest.Collector):
     """Collects all the files related tests"""
 
-    def __init__(self, name: str, parent: pytest.Collector, files: List[dict],
+    def __init__(self, name: str, parent: pytest.Collector,
+                 filetests: List[FileTest],
                  cwd: Union[bytes, str]):
         """
         A WorkflowFilesTestCollector starts all the files-related tests
         :param name: The name of the tests
         :param parent: The collector that started this collector
-        :param files: A list of `files` which are dictionaries in the schema
-        the dictionaries define the tests.
+        :param filetests: A list of `FileTest` which are objects that name
+        all the properties of a to be tested file
         :param cwd: The directory relative to which relative file paths will
         be tested.
         """
-        self.files = files
+        self.filetests = filetests
         self.cwd = cwd
         super().__init__(name, parent=parent)
 
     def collect(self):
         """Starts all file related tests"""
-        filepaths = [Path(x["path"]) for x in self.files]
+        filepaths = [test.path for test in self.filetests]
         # Structure why not the file exists directly?
         # Because also some other operations on files will be added to
         # this list. Like contains, md5sum etc.

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -28,7 +28,7 @@ import yaml
 
 valid_yaml_dir = (Path(__file__).parent / Path("yamls") / Path("valid"))
 valid_yamls = [
-        (valid_yaml_dir / Path("valid_test.yml"))
+        (valid_yaml_dir / Path("dream_file.yaml"))
     ]
 
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -42,7 +42,7 @@ def test_validate_schema(yaml_path):
 
 def test_WorkflowTest():
     with (valid_yaml_dir / Path("dream_file.yaml")).open() as yaml_fh:
-        test_yaml = yaml.load(yaml_fh)
+        test_yaml = yaml.safe_load(yaml_fh)
         tests = [WorkflowTest.from_schema(x) for x in test_yaml]
         assert tests[0].name == "simple echo"
         assert tests[0].files[0].path == Path("log.file")

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -21,7 +21,7 @@ from pathlib import Path
 
 import pytest
 
-from pytest_workflow.schema import validate_schema
+from pytest_workflow.schema import WorkflowTest, validate_schema
 
 import yaml
 
@@ -36,3 +36,16 @@ valid_yamls = [
 def test_validate_schema(yaml_path):
     with yaml_path.open() as yaml_fh:
         validate_schema(yaml.safe_load(yaml_fh))
+
+
+def test_WorkflowTest():
+    with (valid_yaml_dir / Path("dream_file.yaml")).open() as yaml_fh:
+        test_yaml = yaml.load(yaml_fh)
+        tests = [WorkflowTest.from_schema(x) for x in test_yaml]
+        assert tests[0].name == "simple echo"
+        assert tests[0].files[0].path == Path("log.file")
+        assert len(tests[0].files[0].contains) == 3
+        assert len(tests[0].files[0].must_not_contain) == 1
+        assert len(tests[0].files) == 1
+        assert tests[0].stdout.contains == ["bla"]
+        assert tests[0].exit_code == 127

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -19,6 +19,8 @@
 
 from pathlib import Path
 
+import jsonschema
+
 import pytest
 
 from pytest_workflow.schema import WorkflowTest, validate_schema
@@ -49,3 +51,18 @@ def test_WorkflowTest():
         assert len(tests[0].files) == 1
         assert tests[0].stdout.contains == ["bla"]
         assert tests[0].exit_code == 127
+
+
+def test_validate_schema_conflicting_keys():
+    with pytest.raises(jsonschema.ValidationError) as error:
+        validate_schema([
+            dict(name="bla",
+                 command="cowsay moo",
+                 files=[dict(
+                     path="/some/path",
+                     should_exist=False,
+                     must_not_contain=["bla"]
+                 )])
+        ])
+    assert error.match("Content checking not allowed on non existing" +
+                       " file: /some/path. Key = must_not_contain")

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -23,7 +23,8 @@ import jsonschema
 
 import pytest
 
-from pytest_workflow.schema import WorkflowTest, validate_schema
+from pytest_workflow.schema import WorkflowTest, validate_schema, \
+    workflow_tests_from_schema
 
 import yaml
 
@@ -66,3 +67,10 @@ def test_validate_schema_conflicting_keys():
         ])
     assert error.match("Content checking not allowed on non existing" +
                        " file: /some/path. Key = must_not_contain")
+
+
+def test_workflow_tests_from_schema():
+    with (valid_yaml_dir / Path("dream_file.yaml")).open() as yaml_fh:
+        test_yaml = yaml.load(yaml_fh)
+        workflow_tests = workflow_tests_from_schema(test_yaml)
+        assert len(workflow_tests) == 2

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -25,11 +25,10 @@ import jsonschema
 
 import pytest
 
-from pytest_workflow.schema import WorkflowTest, validate_schema, \
+from pytest_workflow.schema import FileTest, WorkflowTest, validate_schema, \
     workflow_tests_from_schema
 
 import yaml
-
 
 valid_yaml_dir = Path(__file__).parent / Path("yamls") / Path("valid")
 valid_yamls = os.listdir(valid_yaml_dir.__str__())
@@ -74,3 +73,22 @@ def test_workflow_tests_from_schema():
         test_yaml = yaml.load(yaml_fh)
         workflow_tests = workflow_tests_from_schema(test_yaml)
         assert len(workflow_tests) == 2
+
+
+def test_workflow_test_defaults():
+    workflow_test = WorkflowTest.from_schema(
+        dict(name="minimal", command="cowsay minimal"))
+    assert workflow_test.files == []
+    assert workflow_test.stdout.contains == []
+    assert workflow_test.stdout.must_not_contain == []
+    assert workflow_test.stderr.contains == []
+    assert workflow_test.stderr.must_not_contain == []
+    assert workflow_test.exit_code == 0
+
+
+def test_filtest_defaults():
+    file_test = FileTest.from_dict(dict(path="bla"))
+    assert file_test.contains == []
+    assert file_test.must_not_contain == []
+    assert file_test.md5sum is None
+    assert file_test.should_exist

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -17,6 +17,8 @@
 
 # This file contains tests for the schema for the yaml file
 
+
+import os
 from pathlib import Path
 
 import jsonschema
@@ -29,15 +31,13 @@ from pytest_workflow.schema import WorkflowTest, validate_schema, \
 import yaml
 
 
-valid_yaml_dir = (Path(__file__).parent / Path("yamls") / Path("valid"))
-valid_yamls = [
-        (valid_yaml_dir / Path("dream_file.yaml"))
-    ]
+valid_yaml_dir = Path(__file__).parent / Path("yamls") / Path("valid")
+valid_yamls = os.listdir(valid_yaml_dir.__str__())
 
 
 @pytest.mark.parametrize("yaml_path", valid_yamls)
 def test_validate_schema(yaml_path):
-    with yaml_path.open() as yaml_fh:
+    with Path(valid_yaml_dir / Path(yaml_path)).open() as yaml_fh:
         validate_schema(yaml.safe_load(yaml_fh))
 
 

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -1,5 +1,3 @@
-from pathlib import Path
-
 from pytest_workflow.workflow import Workflow
 
 

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -4,22 +4,22 @@ from pytest_workflow.workflow import Workflow
 
 
 def test_stdout():
-    workflow = Workflow(Path("echo"), ["moo"])
+    workflow = Workflow("echo moo")
     workflow.run()
     assert workflow.stdout == b"moo\n"
 
 
 def test_exit_code():
-    workflow = Workflow(Path("echo"), ["moo"])
+    workflow = Workflow("echo moo")
     workflow.run()
     assert workflow.exit_code == 0
-    workflow2 = Workflow(Path("grep"), [])
+    workflow2 = Workflow("grep")
     workflow2.run()
     assert workflow2.exit_code == 2
 
 
 def test_stderr():
     # This will fail and print a shortened grep usage.
-    workflow = Workflow(Path("grep"), [])
+    workflow = Workflow("grep")
     workflow.run()
     assert "grep" in str(workflow.stderr)

--- a/tests/workflow_tests/test_simple_echo.yml
+++ b/tests/workflow_tests/test_simple_echo.yml
@@ -1,7 +1,4 @@
-name: simple echo
-executable: "touch"
-arguments:
-  - "log.file"
-results:
+- name: simple touch
+  command: "touch log.file"
   files:
     - path: "log.file"

--- a/tests/yamls/valid/dream_file.yaml
+++ b/tests/yamls/valid/dream_file.yaml
@@ -1,7 +1,7 @@
 - name: simple echo
   files:
     - path: "log.file"
-      md5sum: ""
+      md5sum: "e583af1f8b00b53cda87ae9ead880224"
       contains:
         - "bla"
         - "die"

--- a/tests/yamls/valid/dream_file.yaml
+++ b/tests/yamls/valid/dream_file.yaml
@@ -21,3 +21,8 @@
       - "bla"
   exit_code: 127
   command: "the one string"
+- name: other test
+  command: "cowsay moo"
+  stdout:
+    contains:
+      - "moo"

--- a/tests/yamls/valid/dream_file.yaml
+++ b/tests/yamls/valid/dream_file.yaml
@@ -1,0 +1,23 @@
+- name: simple echo
+  files:
+    - path: "log.file"
+      md5sum: ""
+      contains:
+        - "bla"
+        - "die"
+        - "blabla"
+      exists: false
+      may_not_contain:
+        - "stuff"
+  stdout:
+    contains:
+      - "bla"
+    may_not_contain:
+      - "bla"
+  stderr:
+    contains:
+      - "bla"
+    may_not_contain:
+      - "bla"
+  exit_code: 127
+  command: "the one string"

--- a/tests/yamls/valid/dream_file.yaml
+++ b/tests/yamls/valid/dream_file.yaml
@@ -6,7 +6,6 @@
         - "bla"
         - "die"
         - "blabla"
-      exists: false
       may_not_contain:
         - "stuff"
   stdout:
@@ -23,6 +22,9 @@
   command: "the one string"
 - name: other test
   command: "cowsay moo"
+  files:
+    - path: moo
+      should_exist: false
   stdout:
     contains:
       - "moo"

--- a/tests/yamls/valid/dream_file.yaml
+++ b/tests/yamls/valid/dream_file.yaml
@@ -6,17 +6,17 @@
         - "bla"
         - "die"
         - "blabla"
-      may_not_contain:
+      must_not_contain:
         - "stuff"
   stdout:
     contains:
       - "bla"
-    may_not_contain:
+    must_not_contain:
       - "bla"
   stderr:
     contains:
       - "bla"
-    may_not_contain:
+    must_not_contain:
       - "bla"
   exit_code: 127
   command: "the one string"

--- a/tests/yamls/valid/valid_test.yml
+++ b/tests/yamls/valid/valid_test.yml
@@ -1,9 +1,5 @@
-name: "Some random valid test"
-executable: "/bin/bla"
-arguments:
-  - "bla"
-  - "bla"
-results:
+- name: "Some random valid test"
+  command: "bla"
   files:
     - path: "bladiebla"
     - path: "/bla/bla"


### PR DESCRIPTION
Rewrote the schema for pytest_workflow to match `dream_file.yaml`'s schema. This was discussed in a meeting for workflow testing requirements.

I changed the structure. In `schema.py` the schema is now parsed in a `WorkflowTest` class which has members that resemble the schema. Also sane defaults are set here. This prevents the input yamls from being parsed troughout the pytest-workflow code base. It happens in one place now. Also the named members are presumably more informative than dict().get whatever statements.