### PR TITLE
Integrate static code analysis.

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -4,4 +4,4 @@ disable=wrong-import-order,  # This conflicts with flake8-import-order
         W0511, # We can figure out the fixme's later.
         missing-docstring
         # Sometimes docstrings are missing because they add visual clutter on self-documenting methods.
-        # Adding `# pylint: disable missing-docstrings this method is self-documenting does not help!`
+        # Adding `# pylint: disable missing-docstrings because this method is self-documenting` does not help with the visual clutter!

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,7 +1,7 @@
 [MESSAGES CONTROL]
 disable=wrong-import-order,  # This conflicts with flake8-import-order
-        useless-object-inheritance,
-        # Apparently inheriting from object is not needed in python 3,
-        # but I like this explicitness
+        useless-object-inheritance, # Apparently inheriting from object is not needed in python 3, but I like this explicitness
         W0511, # We can figure out the fixme's later.
-        C0111 # Sometimes docstrings are missing because they add visual clutter on self-documenting methods
+        missing-docstring
+        # Sometimes docstrings are missing because they add visual clutter on self-documenting methods.
+        # Adding `# pylint: disable missing-docstrings this method is self-documenting does not help!`

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,2 +1,7 @@
 [MESSAGES CONTROL]
-disable=wrong-import-order  # This conflicts with flake8-import-order
+disable=wrong-import-order,  # This conflicts with flake8-import-order
+        useless-object-inheritance,
+        # Apparently inheriting from object is not needed in python 3,
+        # but I like this explicitness
+        W0511, # We can figure out the fixme's later.
+        C0111 # Sometimes docstrings are missing because they add visual clutter on self-documenting methods

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,2 @@
+[MESSAGES CONTROL]
+disable=wrong-import-order  # This conflicts with flake8-import-order

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -8,6 +8,9 @@ that users understand how the changes affect the new version.
 --->
 
 ## Current development version
++ Our code base is now checked by pylint and bandit as part of our test
+procedure to ensure that our code adheres to python and security best 
+practices.
 + Add functionality to test whether certain strings exist in files, stdout and 
 stderr.
 + Enable easy to understand output when using pytest verbose mode 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,4 +5,4 @@ flake8
 flake8-import-order
 mypy
 bandit
-pytlint
+pylint

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,5 @@ coverage
 flake8
 flake8-import-order
 mypy
+bandit
+pytlint

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pyyaml==3.13
-pytest==4.0.1
+pyyaml
+pytest>=4
 jsonschema

--- a/src/pytest_workflow/content_tests.py
+++ b/src/pytest_workflow/content_tests.py
@@ -80,8 +80,9 @@ def file_to_string_generator(filepath: Path) -> Iterable[str]:
     :param filepath: the file path
     :return: yields lines of the file
     """
-    with filepath.open("r") as f:  # Use 'r' here explicitly as opposed to 'rb'
-        for line in f:
+    # Use 'r' here explicitly as opposed to 'rb'
+    with filepath.open("r") as file_handler:
+        for line in file_handler:
             yield line
 
 

--- a/src/pytest_workflow/file_tests.py
+++ b/src/pytest_workflow/file_tests.py
@@ -114,10 +114,10 @@ def file_md5sum(filepath: Path) -> str:
     """
 
     hasher = hashlib.md5()  # nosec: only used for file integrity
-    with filepath.open('rb') as f:  # Read the file in bytes
+    with filepath.open('rb') as file_handler:  # Read the file in bytes
         # Hardcode the blocksize at 8192 bytes here.
         # This can be changed or made variable when the requirements compel us
         # to do so.
-        for block in iter(lambda: f.read(8192), b''):
+        for block in iter(lambda: file_handler.read(8192), b''):
             hasher.update(block)
     return hasher.hexdigest()

--- a/src/pytest_workflow/file_tests.py
+++ b/src/pytest_workflow/file_tests.py
@@ -113,7 +113,7 @@ def file_md5sum(filepath: Path) -> str:
     :return: a md5sum as hexadecimal string.
     """
 
-    hasher = hashlib.md5()
+    hasher = hashlib.md5()  # nosec: only used for file integrity
     with filepath.open('rb') as f:  # Read the file in bytes
         # Hardcode the blocksize at 8192 bytes here.
         # This can be changed or made variable when the requirements compel us

--- a/src/pytest_workflow/plugin.py
+++ b/src/pytest_workflow/plugin.py
@@ -18,7 +18,7 @@
 
 import os
 import tempfile
-from distutils.dir_util import copy_tree
+from distutils.dir_util import copy_tree  # pylint: disable=E0611,E0401 # fpos.
 
 import pytest
 
@@ -30,10 +30,10 @@ from .schema import WorkflowTest, workflow_tests_from_schema
 from .workflow import Workflow
 
 
-def pytest_collect_file(path, parent):
+def pytest_collect_file(path, parent):  # pylint: disable=R1710 #pytestspecific
     """Collection hook
-    This collects the yaml files called r'test.*\.ya?ml'"""  # noqa: W605
-    # noqa ignores invalid escape sequence in the regex.
+    This collects the yaml files that start with "test" and end with
+    .yaml or .yml"""
     if path.ext in [".yml", ".yaml"] and path.basename.startswith("test"):
         return YamlFile(path, parent)
 

--- a/src/pytest_workflow/plugin.py
+++ b/src/pytest_workflow/plugin.py
@@ -31,13 +31,13 @@ from .schema import WorkflowTest, workflow_tests_from_schema
 from .workflow import Workflow
 
 
-# Disable inconsistent-return-statements check for pylint specific function.
-def pytest_collect_file(path, parent):  # pylint: disable=R1710
+def pytest_collect_file(path, parent):
     """Collection hook
     This collects the yaml files that start with "test" and end with
     .yaml or .yml"""
     if path.ext in [".yml", ".yaml"] and path.basename.startswith("test"):
         return YamlFile(path, parent)
+    return None
 
 
 class YamlFile(pytest.File):

--- a/src/pytest_workflow/plugin.py
+++ b/src/pytest_workflow/plugin.py
@@ -18,7 +18,8 @@
 
 import os
 import tempfile
-from distutils.dir_util import copy_tree  # pylint: disable=E0611,E0401 # fpos.
+# Disable pylint here because of false positive
+from distutils.dir_util import copy_tree  # pylint: disable=E0611,E0401
 
 import pytest
 
@@ -30,7 +31,8 @@ from .schema import WorkflowTest, workflow_tests_from_schema
 from .workflow import Workflow
 
 
-def pytest_collect_file(path, parent):  # pylint: disable=R1710 #pytestspecific
+# Disable inconsistent-return-statements check for pylint specific function.
+def pytest_collect_file(path, parent):  # pylint: disable=R1710
     """Collection hook
     This collects the yaml files that start with "test" and end with
     .yaml or .yml"""

--- a/src/pytest_workflow/schema.py
+++ b/src/pytest_workflow/schema.py
@@ -56,7 +56,7 @@ def validate_schema(instance):
         """
         contains = dictionary.get("contains", [])
         must_not_contain = dictionary.get("must_not_contain", [])
-        if len(contains) > 0 and len(must_not_contain) > 0:
+        if contains and must_not_contain:
             common_members = set(contains).intersection(set(must_not_contain))
             if common_members != set():
                 raise jsonschema.ValidationError(

--- a/src/pytest_workflow/schema.py
+++ b/src/pytest_workflow/schema.py
@@ -97,7 +97,7 @@ class ContentTest(object):
     present in the file/text
     Everything in `must_not_contain` should not be present.
     """
-
+    # pylint: disable=too-few-public-methods  # for schema class
     def __init__(self, contains: Optional[List[str]] = None,
                  must_not_contain: Optional[List[str]] = None):
         if contains:
@@ -119,6 +119,7 @@ class ContentTest(object):
 
 class FileTest(ContentTest):
     """A class that contains all the properties of a to be tested file."""
+    # pylint: disable=too-few-public-methods  # for schema class
 
     def __init__(self, path: str, md5sum: Optional[str] = None,
                  should_exist: bool = DEFAULT_FILE_SHOULD_EXIST,
@@ -158,6 +159,7 @@ class FileTest(ContentTest):
 
 class WorkflowTest(object):
     """A class that contains all properties of a to be tested workflow"""
+    # pylint: disable=too-few-public-methods  # for schema class
 
     def __init__(self, name: str, command: str,
                  exit_code: int = DEFAULT_EXIT_CODE,

--- a/src/pytest_workflow/schema.py
+++ b/src/pytest_workflow/schema.py
@@ -134,6 +134,7 @@ class FileTest(ContentTest):
         :param must_not_contain: a list of strings that should not be present
         in the file
         """
+        # pylint: disable=too-many-arguments  # class is value container
         super().__init__(contains=contains, must_not_contain=must_not_contain)
         self.path = Path(path)
         self.md5sum = md5sum
@@ -175,6 +176,7 @@ class WorkflowTest(object):
         :param stderr: a ContentTest object
         :param files: a list of FileTest objects
         """
+        # pylint: disable=too-many-arguments  # class is value container
         self.name = name
         self.command = command
         self.exit_code = exit_code

--- a/src/pytest_workflow/schema.py
+++ b/src/pytest_workflow/schema.py
@@ -56,7 +56,7 @@ def validate_schema(instance):
         """
         contains = dictionary.get("contains", [])
         must_not_contain = dictionary.get("must_not_contain", [])
-        if contains and must_not_contain:
+        if len(contains) > 0 and len(must_not_contain) > 0:  # noqa: E501; pylint: disable=len-as-condition; This is more explicit
             common_members = set(contains).intersection(set(must_not_contain))
             if common_members != set():
                 raise jsonschema.ValidationError(

--- a/src/pytest_workflow/schema.py
+++ b/src/pytest_workflow/schema.py
@@ -97,7 +97,8 @@ class ContentTest(object):
     present in the file/text
     Everything in `must_not_contain` should not be present.
     """
-    # pylint: disable=too-few-public-methods  # for schema class
+    # This is a value container. Disabled irrelevant pylint warning.
+    # pylint: disable=too-few-public-methods
     def __init__(self, contains: Optional[List[str]] = None,
                  must_not_contain: Optional[List[str]] = None):
         if contains:
@@ -119,7 +120,8 @@ class ContentTest(object):
 
 class FileTest(ContentTest):
     """A class that contains all the properties of a to be tested file."""
-    # pylint: disable=too-few-public-methods  # for schema class
+    # This is a value container. Disabled irrelevant pylint warning.
+    # pylint: disable=too-few-public-methods
 
     def __init__(self, path: str, md5sum: Optional[str] = None,
                  should_exist: bool = DEFAULT_FILE_SHOULD_EXIST,
@@ -134,7 +136,8 @@ class FileTest(ContentTest):
         :param must_not_contain: a list of strings that should not be present
         in the file
         """
-        # pylint: disable=too-many-arguments  # class is value container
+        # This is a value container. Disabled irrelevant pylint warning.
+        # pylint: disable=too-many-arguments
         super().__init__(contains=contains, must_not_contain=must_not_contain)
         self.path = Path(path)
         self.md5sum = md5sum
@@ -160,7 +163,8 @@ class FileTest(ContentTest):
 
 class WorkflowTest(object):
     """A class that contains all properties of a to be tested workflow"""
-    # pylint: disable=too-few-public-methods  # for schema class
+    # This is a value container. Disabled irrelevant pylint warning.
+    # pylint: disable=too-few-public-methods
 
     def __init__(self, name: str, command: str,
                  exit_code: int = DEFAULT_EXIT_CODE,
@@ -176,7 +180,8 @@ class WorkflowTest(object):
         :param stderr: a ContentTest object
         :param files: a list of FileTest objects
         """
-        # pylint: disable=too-many-arguments  # class is value container
+        # This is a value container. Disabled irrelevant pylint warning.
+        # pylint: disable=too-many-arguments
         self.name = name
         self.command = command
         self.exit_code = exit_code

--- a/src/pytest_workflow/workflow.py
+++ b/src/pytest_workflow/workflow.py
@@ -20,7 +20,7 @@ on stdout, stderr and exit code.
 This file was created by A.H.B. Bollen
 """
 import shlex
-import subprocess
+import subprocess  # nosec: security implications have been considered
 from typing import Union
 
 
@@ -41,7 +41,7 @@ class Workflow(object):
 
     def run(self) -> subprocess.CompletedProcess:
         sub_procces_args = shlex.split(self.command)
-        self._proc_out = subprocess.run(
+        self._proc_out = subprocess.run(  # nosec: Shell is not enabled.
             sub_procces_args, stdout=subprocess.PIPE,
             stderr=subprocess.PIPE, cwd=self.cwd)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,2 +1,2 @@
 # Enabling 'pytester' plugin which was written to help testing pytest plugins.
-pytest_plugins = ["pytester"]
+pytest_plugins = ["pytester"]  # pylint: disable=invalid-name  # pytestspecific

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,2 +1,3 @@
 # Enabling 'pytester' plugin which was written to help testing pytest plugins.
-pytest_plugins = ["pytester"]  # pylint: disable=invalid-name  # pytestspecific
+# Disable pylint invalid name checking for pytest  specific name
+pytest_plugins = ["pytester"]  # pylint: disable=invalid-name

--- a/tests/test_content_functions.py
+++ b/tests/test_content_functions.py
@@ -27,7 +27,7 @@ LICENSE = Path(__file__).parent / Path("content_files") / Path("LICENSE")
 
 # Yes we are checking the AGPLv3+. I am pretty sure some strings will not be
 # there
-succeeding_tests = [
+SUCCEEDING_TESTS = [
     # Test both finding and not finding
     (["When we speak of free software"],
      ["All hail Google, Guardian of our privacy"]),
@@ -39,7 +39,7 @@ succeeding_tests = [
 
 
 @pytest.mark.parametrize(["contains_strings", "does_not_contain_strings"],
-                         succeeding_tests)
+                         SUCCEEDING_TESTS)
 def test_check_content_succeeding(contains_strings, does_not_contain_strings):
     all_strings = set(contains_strings).union(set(does_not_contain_strings))
     found_strings = check_content(list(all_strings),

--- a/tests/test_file_functions.py
+++ b/tests/test_file_functions.py
@@ -22,14 +22,14 @@ import pytest
 
 from pytest_workflow.file_tests import file_md5sum
 
-hash_file_dir = Path(Path(__file__).parent / Path("hash_files"))
+HASH_FILE_DIR = Path(Path(__file__).parent / Path("hash_files"))
 
-hash_files_relative = os.listdir(hash_file_dir.absolute().__str__())
+HASH_FILES_RELATIVE = os.listdir(HASH_FILE_DIR.absolute().__str__())
 
-hash_files = [Path(hash_file_dir / Path(x)) for x in hash_files_relative]
+HASH_FILES = [Path(HASH_FILE_DIR / Path(x)) for x in HASH_FILES_RELATIVE]
 
 
-@pytest.mark.parametrize("hash_file", hash_files)
+@pytest.mark.parametrize("hash_file", HASH_FILES)
 def test_file_md5sum(hash_file: Path):
     # No sec added because this hash is only used for checking file integrity
     whole_file_md5 = hashlib.md5(hash_file.read_bytes()).hexdigest()  # nosec

--- a/tests/test_file_functions.py
+++ b/tests/test_file_functions.py
@@ -31,6 +31,7 @@ hash_files = [Path(hash_file_dir / Path(x)) for x in hash_files_relative]
 
 @pytest.mark.parametrize("hash_file", hash_files)
 def test_file_md5sum(hash_file: Path):
-    whole_file_md5 = hashlib.md5(hash_file.read_bytes()).hexdigest()
+    # No sec added because this hash is only used for checking file integrity
+    whole_file_md5 = hashlib.md5(hash_file.read_bytes()).hexdigest()  # nosec
     per_line_md5 = file_md5sum(hash_file)
     assert whole_file_md5 == per_line_md5

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -107,7 +107,7 @@ def test_validate_schema_contains_conflict(instance):
 
 def test_workflow_tests_from_schema():
     with (valid_yaml_dir / Path("dream_file.yaml")).open() as yaml_fh:
-        test_yaml = yaml.load(yaml_fh)
+        test_yaml = yaml.safe_load(yaml_fh)
         workflow_tests = workflow_tests_from_schema(test_yaml)
         assert len(workflow_tests) == 2
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -41,7 +41,7 @@ def test_validate_schema(yaml_path):
 
 
 def test_workflowtest():
-    with (VALID_YAML_DIR / Path("dream_file.yaml")).open() as yaml_fh:
+    with Path(VALID_YAML_DIR / Path("dream_file.yaml")).open() as yaml_fh:
         test_yaml = yaml.safe_load(yaml_fh)
         tests = [WorkflowTest.from_schema(x) for x in test_yaml]
         assert tests[0].name == "simple echo"

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -30,18 +30,18 @@ from pytest_workflow.schema import FileTest, WorkflowTest, validate_schema, \
 
 import yaml
 
-valid_yaml_dir = Path(__file__).parent / Path("yamls") / Path("valid")
-valid_yamls = os.listdir(valid_yaml_dir.__str__())
+VALID_YAML_DIR = Path(__file__).parent / Path("yamls") / Path("valid")
+VALID_YAMLS = os.listdir(VALID_YAML_DIR.__str__())
 
 
-@pytest.mark.parametrize("yaml_path", valid_yamls)
+@pytest.mark.parametrize("yaml_path", VALID_YAMLS)
 def test_validate_schema(yaml_path):
-    with Path(valid_yaml_dir / Path(yaml_path)).open() as yaml_fh:
+    with Path(VALID_YAML_DIR / Path(yaml_path)).open() as yaml_fh:
         validate_schema(yaml.safe_load(yaml_fh))
 
 
-def wtest_WorkflowTest():
-    with (valid_yaml_dir / Path("dream_file.yaml")).open() as yaml_fh:
+def test_workflowtest():
+    with (VALID_YAML_DIR / Path("dream_file.yaml")).open() as yaml_fh:
         test_yaml = yaml.safe_load(yaml_fh)
         tests = [WorkflowTest.from_schema(x) for x in test_yaml]
         assert tests[0].name == "simple echo"
@@ -68,7 +68,7 @@ def test_validate_schema_conflicting_keys():
                        " file: /some/path. Key = must_not_contain")
 
 
-contains_list = [
+CONTAINS_LIST = [
     """
     - name: bla
       command: bla
@@ -96,17 +96,18 @@ contains_list = [
 
 @pytest.mark.parametrize("instance",
                          [yaml.safe_load(workflow) for workflow in
-                          contains_list])
+                          CONTAINS_LIST])
 def test_validate_schema_contains_conflict(instance):
-    with pytest.raises(jsonschema.ValidationError) as e:
+    with pytest.raises(jsonschema.ValidationError) as errormsg:
         validate_schema(instance)
-    assert e.match("contains and must_not_contain are not allowed to have "
-                   "the same members for the same object.")
-    assert e.match(" Common members: {'bla'}")
+    assert errormsg.match(
+        "contains and must_not_contain are not allowed to have "
+        "the same members for the same object.")
+    assert errormsg.match(" Common members: {'bla'}")
 
 
 def test_workflow_tests_from_schema():
-    with (valid_yaml_dir / Path("dream_file.yaml")).open() as yaml_fh:
+    with (VALID_YAML_DIR / Path("dream_file.yaml")).open() as yaml_fh:
         test_yaml = yaml.safe_load(yaml_fh)
         workflow_tests = workflow_tests_from_schema(test_yaml)
         assert len(workflow_tests) == 2

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -107,7 +107,7 @@ def test_validate_schema_contains_conflict(instance):
 
 
 def test_workflow_tests_from_schema():
-    with (VALID_YAML_DIR / Path("dream_file.yaml")).open() as yaml_fh:
+    with Path(VALID_YAML_DIR / Path("dream_file.yaml")).open() as yaml_fh:
         test_yaml = yaml.safe_load(yaml_fh)
         workflow_tests = workflow_tests_from_schema(test_yaml)
         assert len(workflow_tests) == 2

--- a/tox.ini
+++ b/tox.ini
@@ -11,8 +11,9 @@ whitelist_externals=
     sed
 commands =
     flake8 src tests setup.py
-    # Skip 'assert used' issue as this is a pytest plugin.
-    bandit -s B101 -r src/ tests/
+    # Skip 'assert used' issue as this is a pytest plugin.'
+    # Use csv format because it has cleanest output.
+    bandit -s B101 -f csv -r src/ tests/
     mypy -m src/pytest_workflow
     # Create HTML coverage report for humans and xml coverage report for external services.
     coverage run --source=pytest_workflow -m py.test -v tests

--- a/tox.ini
+++ b/tox.ini
@@ -6,10 +6,13 @@ deps=pytest
      flake8
      flake8-import-order
      mypy
+     bandit
 whitelist_externals=
     sed
 commands =
     flake8 src tests setup.py
+    # Skip 'assert used' issue as this is a pytest plugin.
+    bandit -s B101 -r src/ tests/
     mypy -m src/pytest_workflow
     # Create HTML coverage report for humans and xml coverage report for external services.
     coverage run --source=pytest_workflow -m py.test -v tests

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ commands =
     # Skip 'assert used' issue as this is a pytest plugin.'
     # Use csv format because it has cleanest output.
     bandit -s B101 -f csv -r src/ tests/
-    pylint src/pytest_workflow/ tests/
+    #pylint src/pytest_workflow/ tests/
     mypy -m src/pytest_workflow
     # Create HTML coverage report for humans and xml coverage report for external services.
     coverage run --source=pytest_workflow -m py.test -v tests

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ commands =
     # Skip 'assert used' issue as this is a pytest plugin.'
     # Use csv format because it has cleanest output.
     bandit -s B101 -f csv -r src/ tests/
-    pylint src/pytest_workflow/ tests/
+    pylint src/pytest_workflow/ tests/*.py
     mypy -m src/pytest_workflow
     # Create HTML coverage report for humans and xml coverage report for external services.
     coverage run --source=pytest_workflow -m py.test -v tests

--- a/tox.ini
+++ b/tox.ini
@@ -8,9 +8,6 @@ deps=pytest
      mypy
      bandit
      pylint
-whitelist_externals=
-    sed
-    bash
 commands =
     flake8 src tests setup.py
     # Skip 'assert used' issue as this is a pytest plugin.'

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ deps=pytest
      flake8-import-order
      mypy
      bandit
+     pylint
 whitelist_externals=
     sed
 commands =
@@ -14,6 +15,7 @@ commands =
     # Skip 'assert used' issue as this is a pytest plugin.'
     # Use csv format because it has cleanest output.
     bandit -s B101 -f csv -r src/ tests/
+    pylint --disable=missing-docstring tests/
     mypy -m src/pytest_workflow
     # Create HTML coverage report for humans and xml coverage report for external services.
     coverage run --source=pytest_workflow -m py.test -v tests

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,7 @@ commands =
     # Skip 'assert used' issue as this is a pytest plugin.'
     # Use csv format because it has cleanest output.
     bandit -s B101 -f csv -r src/ tests/
+    pylint src/pytest_workflow/
     pylint --disable=missing-docstring tests/
     mypy -m src/pytest_workflow
     # Create HTML coverage report for humans and xml coverage report for external services.

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ commands =
     # Skip 'assert used' issue as this is a pytest plugin.'
     # Use csv format because it has cleanest output.
     bandit -s B101 -f csv -r src/ tests/
-    #pylint src/pytest_workflow/ tests/
+    pylint src/pytest_workflow/ tests/
     mypy -m src/pytest_workflow
     # Create HTML coverage report for humans and xml coverage report for external services.
     coverage run --source=pytest_workflow -m py.test -v tests

--- a/tox.ini
+++ b/tox.ini
@@ -16,8 +16,7 @@ commands =
     # Skip 'assert used' issue as this is a pytest plugin.'
     # Use csv format because it has cleanest output.
     bandit -s B101 -f csv -r src/ tests/
-    # Execution in bash needed for travis
-    bash -c 'pylint src/pytest_workflow/ tests/*.py'
+    pylint src/pytest_workflow/ tests/
     mypy -m src/pytest_workflow
     # Create HTML coverage report for humans and xml coverage report for external services.
     coverage run --source=pytest_workflow -m py.test -v tests

--- a/tox.ini
+++ b/tox.ini
@@ -10,12 +10,14 @@ deps=pytest
      pylint
 whitelist_externals=
     sed
+    bash
 commands =
     flake8 src tests setup.py
     # Skip 'assert used' issue as this is a pytest plugin.'
     # Use csv format because it has cleanest output.
     bandit -s B101 -f csv -r src/ tests/
-    pylint src/pytest_workflow/ tests/*.py
+    # Execution in bash needed for travis
+    bash -c 'pylint src/pytest_workflow/ tests/*.py'
     mypy -m src/pytest_workflow
     # Create HTML coverage report for humans and xml coverage report for external services.
     coverage run --source=pytest_workflow -m py.test -v tests

--- a/tox.ini
+++ b/tox.ini
@@ -15,8 +15,7 @@ commands =
     # Skip 'assert used' issue as this is a pytest plugin.'
     # Use csv format because it has cleanest output.
     bandit -s B101 -f csv -r src/ tests/
-    pylint src/pytest_workflow/
-    pylint --disable=missing-docstring tests/
+    pylint src/pytest_workflow/ tests/
     mypy -m src/pytest_workflow
     # Create HTML coverage report for humans and xml coverage report for external services.
     coverage run --source=pytest_workflow -m py.test -v tests


### PR DESCRIPTION
Enable static code analysis by pylint and bandit. This should catch issues before they are noticed by codacy. Also it should make us less dependent on codacy. Furthermore it allows local analysis of the code base.

### Checklist
- [x] Pull request details were added to HISTORY.md
