### PR TITLE
Allow to change temporary directory using `--basetemp`, cleanup directories afterwards, and add `--keep-workflow-wd` flag to disable cleanup. 

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -8,10 +8,11 @@ that users understand how the changes affect the new version.
 --->
 
 ## Current development version
-+ The temporary directories are run are automatically cleaned up at the end
-of each workflow test. You can change this behaviour by using the 
-`--keep-workflow-wd` flag. Which allows you to inspect the working directory
-for debugging after the workflow tests have run.
++ The temporary directories in which workflows are run are automatically 
+cleaned up at the end of each workflow test. You can disable this behaviour 
+by using the `--keep-workflow-wd` flag, which allows you to inspect the working 
+directory after the workflow tests have run. This is useful for debugging 
+workflows.
 + The temporary directories in which workflows are run can now be 
 changed by using the `--basetemp` flag. This is because pytest-workflow now 
 uses the built-in tmpdir capabilities of pytest.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -8,6 +8,13 @@ that users understand how the changes affect the new version.
 --->
 
 ## Current development version
++ The temporary directories are run are automatically cleaned up at the end
+of each workflow test. You can change this behaviour by using the 
+`--keep-workflow-wd` flag. Which allows you to inspect the working directory
+for debugging after the workflow tests have run.
++ The temporary directories in which workflows are run can now be 
+changed by using the `--basetemp` flag. This is because pytest-workflow now 
+uses the built-in tmpdir capabilities of pytest.
 + Save stdout and stderr of each workflow to a file and report their locations
 to stdout when running `pytest`.
 + Comprehensible failure messages were added to make debugging workflows

--- a/README.md
+++ b/README.md
@@ -26,7 +26,13 @@ Run `pytest` from an environment with pytest-workflow installed.
 Pytest will automatically gather files in the `tests` directory starting with 
 `test` and ending in `.yaml` or `.yml`. 
 
-The tests are run automatically.
+The workflows are run automatically. Each workflow gets its own temporary 
+directory to run. These directories are cleaned up after the tests are 
+completed. If you wish to inspect the output of a failing workflow you can use
+the `--keep-workflow-wd` flag to disable cleanup.
+
+If you wish to change the temporary directory in which the workflows are run
+use `--basetemp <dir>` to change pytest's base temp directory.
 
 ## Writing tests with pytest-workflow
 

--- a/src/pytest_workflow/plugin.py
+++ b/src/pytest_workflow/plugin.py
@@ -98,7 +98,7 @@ class WorkflowTestsCollector(pytest.Collector):
 
         # Create a workflow and make sure it runs in the tempdir
         workflow = Workflow(self.workflow_test.command, tempdir)
-        name = self.workflow_test.name
+
         # Use print statements here. Using pytests internal logwriter has no
         # added value. If there are wishes to do so in the future, the pytest
         # terminal writer can be acquired with:
@@ -106,19 +106,19 @@ class WorkflowTestsCollector(pytest.Collector):
         # Name is included explicitly in each print command to avoid confusion
         # between workflows
         print("run '{name}' with command '{command}' in '{dir}'".format(
-            name=name,
+            name=self.name,
             command=self.workflow_test.command,
             dir=tempdir))
         workflow.run()
-        print("run '{name}': done".format(name=name))
+        print("run '{name}': done".format(name=self.name))
 
         if self.config.getoption("keep_workflow_wd", False):
             # Use pytest's internal pathlib to create a cleanup lock file.
             create_cleanup_lock(Path(tempdir))
             log_err = workflow.stderr_to_file()
             log_out = workflow.stdout_to_file()
-            print("'{0}' stdout saved in: {1}".format(name, str(log_out)))
-            print("'{0}' stderr saved in: {1}".format(name, str(log_err)))
+            print("'{0}' stdout saved in: {1}".format(self.name, str(log_out)))
+            print("'{0}' stderr saved in: {1}".format(self.name, str(log_err)))
         return workflow
 
     def collect(self):

--- a/src/pytest_workflow/plugin.py
+++ b/src/pytest_workflow/plugin.py
@@ -92,8 +92,9 @@ class WorkflowTestsCollector(pytest.Collector):
         replacing all whitespaces with '_'. Directory paths with whitespace in
         them are very annoying to inspect.
         Additionally the temporary directories are numbered. This prevents
-        name collisions if tests have the same name. The alternative is
-        overengineering some name collision checking stuff in schema.py.
+        name collisions if tests have the same name (when whitespace is
+        replaced). The alternative is overengineering some name collision
+        checking stuff in schema.py. So this solution was preferred.
 
         Print statements are used to provide information to the user.  Using
         pytests internal logwriter has no added value. If there are wishes to

--- a/src/pytest_workflow/plugin.py
+++ b/src/pytest_workflow/plugin.py
@@ -17,11 +17,9 @@
 """core functionality of pytest-workflow plugin"""
 
 # Disable pylint here because of false positive
-from pathlib import Path
 from shutil import copytree
 
 from _pytest.config import argparsing
-from _pytest.pathlib import create_cleanup_lock
 
 import pytest
 
@@ -114,8 +112,6 @@ class WorkflowTestsCollector(pytest.Collector):
         print("run '{name}': done".format(name=self.name))
 
         if self.config.getoption("keep_workflow_wd", False):
-            # Use pytest's internal pathlib to create a cleanup lock file.
-            create_cleanup_lock(Path(tempdir))
             log_err = workflow.stderr_to_file()
             log_out = workflow.stdout_to_file()
             print("'{0}' stdout saved in: {1}".format(self.name, str(log_out)))

--- a/src/pytest_workflow/plugin.py
+++ b/src/pytest_workflow/plugin.py
@@ -148,11 +148,6 @@ class WorkflowTestsCollector(pytest.Collector):
             content_test=self.workflow_test.stderr)]
 
         return tests
-        # TODO: Figure out proper cleanup.
-        # If tempdir is removed here, all tests will fail.
-        # After yielding the tests this object is no longer needed, so
-        # deleting the tempdir here does not work.
-        # There is probably some fixture that can handle this.
 
 
 class ExitCodeTest(pytest.Item):

--- a/src/pytest_workflow/plugin.py
+++ b/src/pytest_workflow/plugin.py
@@ -92,8 +92,12 @@ class WorkflowTestsCollector(pytest.Collector):
         them are very annoying to inspect.
         Additionally the temporary directories are numbered. This prevents
         name collisions if tests have the same name (when whitespace is
-        replaced). The alternative is overengineering some name collision
-        checking stuff in schema.py. So this solution was preferred.
+        replaced). This is because pytest does not use the stdlib's tempfile
+        and instead uses its own solution. So directories with the same name
+        can have collisions unless numbered is used.
+        The alternative is overengineering some name collision
+        prevention stuff in schema.py. But that will be a lot of work to create
+        and maintain. So using numbers as a solution was preferred.
 
         Print statements are used to provide information to the user.  Using
         pytests internal logwriter has no added value. If there are wishes to

--- a/src/pytest_workflow/plugin.py
+++ b/src/pytest_workflow/plugin.py
@@ -105,7 +105,6 @@ class WorkflowTestsCollector(pytest.Collector):
         # pylint: disable=protected-access
         # Protected access needed to integrate tmpdir fixture functionality.
 
-
         tmpdirhandler = self.config._tmpdirhandler  # type: TempdirFactory
         tempdir = tmpdirhandler.mktemp(
             re.sub(r'\s+', '_', self.name),

--- a/src/pytest_workflow/plugin.py
+++ b/src/pytest_workflow/plugin.py
@@ -117,6 +117,8 @@ class WorkflowTestsCollector(pytest.Collector):
             print("'{0}' stdout saved in: {1}".format(self.name, str(log_out)))
             print("'{0}' stderr saved in: {1}".format(self.name, str(log_err)))
         else:
+            # addfinalizer adds a function that is run when the node tests are
+            # completed
             self.addfinalizer(tempdir_path.remove)
 
         return workflow

--- a/src/pytest_workflow/plugin.py
+++ b/src/pytest_workflow/plugin.py
@@ -36,7 +36,6 @@ def pytest_addoption(parser: argparsing.Parser):
     parser.addoption(
         "--keep-workflow-wd",
         action="store_true",
-        default=False,
         help="Keep temporary directories where workflows are run for "
              "debugging purposes. This also triggers saving of stdout and "
              "stderr in the workflow directory",

--- a/src/pytest_workflow/plugin.py
+++ b/src/pytest_workflow/plugin.py
@@ -15,8 +15,10 @@
 # along with pytest-workflow.  If not, see <https://www.gnu.org/licenses/
 
 """core functionality of pytest-workflow plugin"""
+import re
 
 from _pytest.config import argparsing
+from _pytest.tmpdir import TempdirFactory  # noqa: E501,F401 # used for type annotation
 
 from py._path.local import LocalPath  # noqa: F401 # used for type annotation
 
@@ -87,8 +89,14 @@ class WorkflowTestsCollector(pytest.Collector):
         # from getting filled up with test workflow output.
         # The temporary directory is produced from self.config._tmpdirhandler
         # which  does the same as using a `tmpdir` fixture.
-        tempdir = self.config._tmpdirhandler.mktemp(
-            self.name, numbered=False)  # type: LocalPath
+        tmpdirhandler = self.config._tmpdirhandler  # type: TempdirFactory
+        tempdir = tmpdirhandler.mktemp(
+            re.sub(r'\s+', '_', self.name),  # Replace whitespace with '_'
+            numbered=True  # This will prevent name collisions for tests
+            # with the same name by appending numbers to each dir. The
+            # alternative is overengineering some name checking stuff in
+            # schema.py.
+        )  # type: LocalPath
 
         # Copy the project directory to the temporary directory using pytest's
         # rootdir.

--- a/src/pytest_workflow/plugin.py
+++ b/src/pytest_workflow/plugin.py
@@ -37,6 +37,7 @@ def pytest_addoption(parser: argparsing.Parser):
     parser.addoption(
         "--keep-workflow-wd",
         action="store_true",
+        default=False,
         help="Keep temporary directories where workflows are run for "
              "debugging purposes. This also triggers saving of stdout and "
              "stderr in the workflow directory",
@@ -111,7 +112,7 @@ class WorkflowTestsCollector(pytest.Collector):
         workflow.run()
         print("run '{name}': done".format(name=name))
 
-        if self.config.keep_workflow_temp:
+        if self.config.getoption("keep_workflow_wd", False):
             # Use pytest's internal pathlib to create a cleanup lock file.
             create_cleanup_lock(Path(tempdir))
             log_err = workflow.stderr_to_file()

--- a/src/pytest_workflow/plugin.py
+++ b/src/pytest_workflow/plugin.py
@@ -18,6 +18,9 @@
 
 # Disable pylint here because of false positive
 from distutils.dir_util import copy_tree  # pylint: disable=E0611,E0401
+from pathlib import Path
+
+from _pytest.pathlib import create_cleanup_lock
 
 import pytest
 
@@ -79,6 +82,7 @@ class WorkflowTestsCollector(pytest.Collector):
             self.config._tmpdirhandler.mktemp(  # noqa # pylint: disable=protected-access
                 self.name, numbered=False)
         )
+        create_cleanup_lock(Path(tempdir))
         # Copy the project directory to the temporary directory using pytest's
         # rootdir.
         copy_tree(str(self.config.rootdir), tempdir)

--- a/src/pytest_workflow/plugin.py
+++ b/src/pytest_workflow/plugin.py
@@ -79,25 +79,24 @@ class WorkflowTestsCollector(pytest.Collector):
         super().__init__(workflow_test.name, parent=parent)
 
     def run_workflow(self):
-        # pylint: disable=protected-access
         """Runs the workflow in a temporary directory"""
+        # pylint: disable=protected-access
+        # Protected access needed to integrate tmpdir fixture functionality.
 
         # Running in a temporary directory will prevent the project repository
         # from getting filled up with test workflow output.
         # The temporary directory is produced from self.config._tmpdirhandler
         # which  does the same as using a `tmpdir` fixture.
-        tempdir_path = self.config._tmpdirhandler.mktemp(
+        tempdir = self.config._tmpdirhandler.mktemp(
             self.name, numbered=False)  # type: LocalPath
-
-        tempdir = str(tempdir_path)
 
         # Copy the project directory to the temporary directory using pytest's
         # rootdir.
         rootdir = self.config.rootdir  # type: LocalPath
-        rootdir.copy(tempdir_path)
+        rootdir.copy(tempdir)
 
         # Create a workflow and make sure it runs in the tempdir
-        workflow = Workflow(self.workflow_test.command, tempdir)
+        workflow = Workflow(self.workflow_test.command, str(tempdir))
 
         # Use print statements here. Using pytests internal logwriter has no
         # added value. If there are wishes to do so in the future, the pytest
@@ -120,7 +119,7 @@ class WorkflowTestsCollector(pytest.Collector):
         else:
             # addfinalizer adds a function that is run when the node tests are
             # completed
-            self.addfinalizer(tempdir_path.remove)
+            self.addfinalizer(tempdir.remove)
 
         return workflow
 

--- a/src/pytest_workflow/plugin.py
+++ b/src/pytest_workflow/plugin.py
@@ -16,7 +16,6 @@
 
 """core functionality of pytest-workflow plugin"""
 
-import tempfile
 # Disable pylint here because of false positive
 from distutils.dir_util import copy_tree  # pylint: disable=E0611,E0401
 
@@ -74,8 +73,12 @@ class WorkflowTestsCollector(pytest.Collector):
         # Create a temporary directory where the workflow is run.
         # This will prevent the project repository from getting filled up with
         # test workflow output.
-        tempdir = tempfile.mkdtemp(prefix="pytest_wf")
-
+        # The temporary directory is produced from self.config._tmpdirhandler
+        # which  does the same as using a `tmpdir` fixture.
+        tempdir = str(
+            self.config._tmpdirhandler.mktemp(  # noqa # pylint: disable=protected-access
+                self.name, numbered=False)
+        )
         # Copy the project directory to the temporary directory using pytest's
         # rootdir.
         copy_tree(str(self.config.rootdir), tempdir)

--- a/tests/test_success_messages.py
+++ b/tests/test_success_messages.py
@@ -17,9 +17,10 @@
 
 import shutil
 import subprocess  # nosec
-import tempfile
 import textwrap
 from pathlib import Path
+
+from _pytest.tmpdir import TempdirFactory
 
 import pytest
 
@@ -81,14 +82,14 @@ SUCCESS_MESSAGES = [
 ]
 
 
-@pytest.fixture(scope="module")
-def succeeding_tests_output():
+@pytest.fixture(scope="session")
+def succeeding_tests_output(tmpdir_factory: TempdirFactory):
     """This fixture was written because the testdir function has a default
     scope of 'function'. This is very inefficient when testing multiple
     success messages in the output as the whole test yaml with all commands
     has to be run again.
     This fixture runs the succeeding tests once with pytest -v"""
-    tempdir = tempfile.mkdtemp()
+    tempdir = str(tmpdir_factory.mktemp("succeeding_tests"))
     test_file = Path(Path(tempdir) / Path("test_succeeding.yml"))
     with test_file.open("w") as file_handler:
         file_handler.write(SUCCEEDING_TESTS_YAML)

--- a/tests/test_success_messages.py
+++ b/tests/test_success_messages.py
@@ -24,7 +24,7 @@ from _pytest.tmpdir import TempdirFactory
 
 import pytest
 
-SUCCEEDING_TESTS_YAML = textwrap.dedent("""\
+MOO_FILE = textwrap.dedent("""\
 - name: moo file
   # Gruesome command injection here. This is for testing purposes only.
   # Do not try this at home.
@@ -36,7 +36,9 @@ SUCCEEDING_TESTS_YAML = textwrap.dedent("""\
       must_not_contain:
         - "Cock a doodle doo"  # Unless our cow has severe identity disorders
       md5sum: e583af1f8b00b53cda87ae9ead880224
+""")
 
+SIMPLE_ECHO = textwrap.dedent("""\
 - name: simple echo
   command: "echo moo"
   files:
@@ -47,7 +49,9 @@ SUCCEEDING_TESTS_YAML = textwrap.dedent("""\
       - "moo"
     must_not_contain:
       - "Cock a doodle doo"
+""")
 
+FAILING_GREP = textwrap.dedent("""\
 - name: failing grep
   command: "grep"
   stdout:
@@ -59,6 +63,8 @@ SUCCEEDING_TESTS_YAML = textwrap.dedent("""\
       - "Try 'grep --help'"
   exit_code: 2
 """)
+
+SUCCEEDING_TESTS_YAML = MOO_FILE + SIMPLE_ECHO + FAILING_GREP
 
 SUCCESS_MESSAGES = [
     ["test_succeeding.yml::moo file::exit code should be 0 PASSED"],

--- a/tests/test_success_messages.py
+++ b/tests/test_success_messages.py
@@ -77,8 +77,6 @@ SUCCESS_MESSAGES = [
     ["test_succeeding.yml::failing grep::stderr::contains 'Try 'grep --help''"],  # noqa: E501
     ["run 'moo file' with command 'bash -c 'echo moo > moo.txt'' in"],
     ["run 'moo file': done"],
-    ["'moo file' stdout saved in: "],
-    ["'moo file' stderr saved in: "]
 ]
 
 

--- a/tests/test_temp_directory.py
+++ b/tests/test_temp_directory.py
@@ -51,5 +51,3 @@ def test_directory_not_kept(testdir):
     working_dir = re.search(r"with command 'echo moo' in '(.*)'",
                             result.stdout.str()).group(1)
     assert not Path(working_dir).exists()
-    assert not Path(working_dir / Path("log.out")).exists()
-    assert not Path(working_dir / Path("log.err")).exists()

--- a/tests/test_temp_directory.py
+++ b/tests/test_temp_directory.py
@@ -51,3 +51,5 @@ def test_directory_not_kept(testdir):
     working_dir = re.search(r"with command 'echo moo' in '(.*)'",
                             result.stdout.str()).group(1)
     assert not Path(working_dir).exists()
+    assert not Path(working_dir / Path("log.out")).exists()
+    assert not Path(working_dir / Path("log.err")).exists()

--- a/tests/test_temp_directory.py
+++ b/tests/test_temp_directory.py
@@ -1,0 +1,42 @@
+# Copyright (C) 2018 Leiden University Medical Center
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/
+
+"""Tests whether the temporary directories are correctly saved/destroyed"""
+
+import textwrap
+
+from _pytest.pytester import Testdir
+
+SIMPLE_TEST_YAML = textwrap.dedent("""\
+- name: simple echo
+  command: "echo moo"
+  files:
+    - path: "moo.txt"
+      should_exist: false
+  stdout:
+    contains:
+      - "moo"
+    must_not_contain:
+      - "Cock a doodle doo"
+""")
+
+
+def test_directory_saved(testdir: Testdir):
+    testdir.makefile(".yml", test=SIMPLE_TEST_YAML)
+    testdir.config
+
+
+["'moo file' stdout saved in: "],
+["'moo file' stderr saved in: "]

--- a/tests/test_temp_directory.py
+++ b/tests/test_temp_directory.py
@@ -41,4 +41,13 @@ def test_directory_kept(testdir):
     working_dir = re.search(r"with command 'echo moo' in '(.*)'",
                             result.stdout.str()).group(1)
     assert Path(working_dir).exists()
+    assert Path(working_dir / Path("log.out")).exists()
+    assert Path(working_dir / Path("log.err")).exists()
 
+
+def test_directory_not_kept(testdir):
+    testdir.makefile(".yml", test=SUCCEEDING_TESTS_YAML)
+    result = testdir.runpytest("-v")
+    working_dir = re.search(r"with command 'echo moo' in '(.*)'",
+                            result.stdout.str()).group(1)
+    assert not Path(working_dir).exists()

--- a/tests/test_temp_directory.py
+++ b/tests/test_temp_directory.py
@@ -18,25 +18,25 @@
 import re
 from pathlib import Path
 
-from .test_success_messages import SUCCEEDING_TESTS_YAML
+from .test_success_messages import SIMPLE_ECHO
 
 
 def test_log_messages(testdir):
-    testdir.makefile(".yml", test=SUCCEEDING_TESTS_YAML)
+    testdir.makefile(".yml", test=SIMPLE_ECHO)
     result = testdir.runpytest("-v", "--keep-workflow-wd")
-    assert "'moo file' stdout saved in: " in result.stdout.str()
-    assert "'moo file' stderr saved in: " in result.stdout.str()
+    assert "'simple echo' stdout saved in: " in result.stdout.str()
+    assert "'simple echo' stderr saved in: " in result.stdout.str()
 
 
 def test_not_log_messages(testdir):
-    testdir.makefile(".yml", test=SUCCEEDING_TESTS_YAML)
+    testdir.makefile(".yml", test=SIMPLE_ECHO)
     result = testdir.runpytest("-v")
-    assert "'moo file' stdout saved in: " not in result.stdout.str()
-    assert "'moo file' stderr saved in: " not in result.stdout.str()
+    assert "'simple echo' stdout saved in: " not in result.stdout.str()
+    assert "'simple echo' stderr saved in: " not in result.stdout.str()
 
 
 def test_directory_kept(testdir):
-    testdir.makefile(".yml", test=SUCCEEDING_TESTS_YAML)
+    testdir.makefile(".yml", test=SIMPLE_ECHO)
     result = testdir.runpytest("-v", "--keep-workflow-wd")
     working_dir = re.search(r"with command 'echo moo' in '(.*)'",
                             result.stdout.str()).group(1)
@@ -46,7 +46,7 @@ def test_directory_kept(testdir):
 
 
 def test_directory_not_kept(testdir):
-    testdir.makefile(".yml", test=SUCCEEDING_TESTS_YAML)
+    testdir.makefile(".yml", test=SIMPLE_ECHO)
     result = testdir.runpytest("-v")
     working_dir = re.search(r"with command 'echo moo' in '(.*)'",
                             result.stdout.str()).group(1)


### PR DESCRIPTION
This fixes #3 and #16 

`--basetemp` is a pytest build in that is conveniently reused here.
`--keep-workflow-wd` was the best flag name I could come up with. Suggestions are welcome.

### Checklist
- [x] Pull request details were added to HISTORY.md
