### PR TITLE
remove redundant lines in tox and requirements-doc.txt

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,4 +1,3 @@
 setuptools
 sphinx
 sphinx_rtd_theme
-.

--- a/tox.ini
+++ b/tox.ini
@@ -16,9 +16,6 @@ commands =
 
 # Documentation should build on python version 3
 [testenv:py3-docs]
-# We will install the package via requirements-docs.txt just as
-# what happens on readthedocs
-skip_install = True
 deps=-r requirements-docs.txt
 whitelist_externals=bash
                     make


### PR DESCRIPTION
Readthedocs can install a package using python setup.py install. So
it is no longer necessary to include . in the requirements for docs.
Also the tox environment can be simplified by making this change


### Checklist
~~- [ ] Pull request details were added to HISTORY.rst~~
