### PR TITLE
Add `--tag` flag for easier workflow selection.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,11 @@ Changelog
 .. NOTE: This document is user facing. Please word the changes in such a way
 .. that users understand how the changes affect the new version.
 
+Version 0.4.0-dev
+---------------------------
++ Added ``--tag`` flag to allow for easier selection of workflows during
+  testing.
+
 Version 0.3.0
 ---------------------------
 + Improved the log output to look nicer and make workflow log paths easier to
@@ -28,9 +33,9 @@ Version 0.2.0
 + Start using sphinx and readthedocs.org for creating project documentation.
 + The temporary directories in which workflows are run are automatically
   cleaned up at the end of each workflow test. You can disable this behaviour
-  by using the ``--keep-workflow-wd`` flag, which allows you to inspect the working
-  directory after the workflow tests have run. This is useful for debugging
-  workflows.
+  by using the ``--keep-workflow-wd`` flag, which allows you to inspect the
+  working directory after the workflow tests have run. This is useful for
+  debugging workflows.
 + The temporary directories in which workflows are run can now be
   changed by using the ``--basetemp`` flag. This is because pytest-workflow now
   uses the built-in tmpdir capabilities of pytest.

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -9,6 +9,7 @@ Changelog
 
 Version 0.4.0-dev
 ---------------------------
+
 + Added ``--tag`` flag to allow for easier selection of workflows during
   testing.
 + Adds additional test cases for snakemake pipelines.

--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -27,16 +27,24 @@ its own name and additional tags in the ``tags`` key of the yaml.
 .. code-block:: yaml
 
   - name: moo
+    tags:
+      - animal
     command: echo moo
   - name: cock-a-doodle-doo
     tags:
       - rooster sound
+      - animal
     command: echo cock-a-doodle-doo
+  - name: vroom vroom
+    tags:
+      - car
+    command: echo vroom croom
 
 With the command ``pytest --tag moo`` only the workflow named 'moo' will be
 run. With ``pytest --tag 'rooster sound'`` only the 'cock-a-doodle-doo'
 workflow will run. Multiple tags can be used like this:
-``pytest --tag moo --tag 'rooster sound'``.
+``pytest --tag 'rooster sound' --tag animal`` This will run all workflows that
+have both 'rooster sound' and 'animal'.
 
 ==================================
 Writing tests with pytest-workflow

--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -46,6 +46,19 @@ workflow will run. Multiple tags can be used like this:
 ``pytest --tag 'rooster sound' --tag animal`` This will run all workflows that
 have both 'rooster sound' and 'animal'.
 
+Internally names and tags are handled the same so if the following tests:
+
+.. code-block:: yaml
+
+  - name: hello
+    command: echo 'hello'
+  - name: hello2
+    command: echo 'hello2'
+    tags:
+      - hello
+
+are run with ``pytest --tag hello`` then both ``hello`` and ``hello2`` are run.
+
 ==================================
 Writing tests with pytest-workflow
 ==================================
@@ -107,7 +120,6 @@ A more advanced example:
 The above YAML file contains all the possible options for a workflow test.
 
 
------------------
 Snakemake example
 -----------------
 

--- a/docs/manual.rst
+++ b/docs/manual.rst
@@ -19,6 +19,25 @@ To run multiple workflows simultaneously you can use
 of workflows that can be run simultaneously. This will speed up things if
 you have enough resources to process these workflows simultaneously.
 
+Running specific workflows
+----------------------------
+To run a specific workflow use the ``--tag`` flag. Each workflow is tagged with
+its own name and additional tags in the ``tags`` key of the yaml.
+
+.. code-block:: yaml
+
+  - name: moo
+    command: echo moo
+  - name: cock-a-doodle-doo
+    tags:
+      - rooster sound
+    command: echo cock-a-doodle-doo
+
+With the command ``pytest --tag moo`` only the workflow named 'moo' will be
+run. With ``pytest --tag 'rooster sound'`` only the 'cock-a-doodle-doo'
+workflow will run. Multiple tags can be used like this:
+``pytest --tag moo --tag 'rooster sound'``.
+
 ==================================
 Writing tests with pytest-workflow
 ==================================
@@ -63,6 +82,8 @@ A more advanced example:
         - "Cock a doodle doo"
 
   - name: mission impossible           # Also failing workflows can be tested
+    tags:                              # A list of tags that can be used to select which test
+      - should fail                    # is run with pytest using the `--tag` flag.
     command: bash impossible.sh
     exit_code: 2                       # What the exit code should be (optional, if not given defaults to 0)
     files:

--- a/src/pytest_workflow/plugin.py
+++ b/src/pytest_workflow/plugin.py
@@ -63,8 +63,8 @@ def pytest_addoption(parser: _pytest.config.argparsing.Parser):
     # allow whitespace in names. That is just being plain annoying to the user
     # for no good reason. Maybe the user does not want to use tags, and then it
     # is extra hassle for a feature that is not even used.
-    # So using pytest `-m` is an implementation nightmare. `--tag` is not just
-    # here for "not invented here" reasons.
+    # So using pytest `-m` to select workflows is an implementation nightmare.
+    # `--tag` is an easier solution.
     parser.addoption(
         "--tag",
         dest="workflow_tags",

--- a/src/pytest_workflow/plugin.py
+++ b/src/pytest_workflow/plugin.py
@@ -129,9 +129,6 @@ class WorkflowTestsCollector(pytest.Collector):
         self.tempdir = None  # type: Optional[Path]
         self.workflow = None  # type: Optional[Workflow]
 
-        # Attach a marker to this node to distinguish from other python tests
-        self.add_marker("workflow")
-
         # Attach tags to this node for easier workflow selection
         self.tags = [self.workflow_test.name] + self.workflow_test.tags
 

--- a/src/pytest_workflow/plugin.py
+++ b/src/pytest_workflow/plugin.py
@@ -121,6 +121,13 @@ class WorkflowTestsCollector(pytest.Collector):
         self.tempdir = None  # type: Optional[Path]
         self.workflow = None  # type: Optional[Workflow]
 
+        # Attach markers to this node to allow for easier test selection when
+        # running pytest.
+        self.add_marker("workflow")  # To distinguish from other python tests
+        self.add_marker(self.workflow_test.name)
+        for marker in self.workflow_test.markers:
+            self.add_marker(marker)
+
     def queue_workflow(self):
         """Creates a temporary directory and add the workflow to the workflow
         queue.

--- a/src/pytest_workflow/plugin.py
+++ b/src/pytest_workflow/plugin.py
@@ -48,6 +48,23 @@ def pytest_addoption(parser: _pytest.config.argparsing.Parser):
         default=1,
         type=int,
         help="The number of workflows to run simultaneously.")
+
+    # Why `--tag <tag>` and not simply use `pytest -m <tag>`?
+    # `-m` uses a "mark expression". So you have to type a piece of python
+    # code instead of just supplying the tags you want. This is fine for the
+    # user interface. But this is not fine for the plugin implementation. If
+    # `-m` is used we need to evaluate the mark expression and make sure it
+    # applies to the marks of the workflow. This requires reusing of the pytest
+    # code, which is a hell to implement.
+    # Additionally, markers can not have whitespace. So using the name of a
+    # workflow as a default tag is not possible. Unless you first replace
+    # whitespace for both command line and the test_.yml to make sure the marks
+    # are correct. This is non-trivial. Alternatively, the schema could not
+    # allow whitespace in names. That is just being plain annoying to the user
+    # for no good reason. Maybe the user does not want to use tags, and then it
+    # is extra hassle for a feature that is not even used.
+    # So using pytest `-m` is an implementation nightmare. `--tag` is not just
+    # here for "not invented here" reasons.
     parser.addoption(
         "--tag",
         dest="workflow_tags",

--- a/src/pytest_workflow/plugin.py
+++ b/src/pytest_workflow/plugin.py
@@ -48,6 +48,12 @@ def pytest_addoption(parser: _pytest.config.argparsing.Parser):
         default=1,
         type=int,
         help="The number of workflows to run simultaneously.")
+    parser.addoption(
+        "--tag",
+        dest="workflow_tags",
+        action="append",
+        type=str,
+    )
 
 
 def pytest_collect_file(path, parent):
@@ -121,12 +127,11 @@ class WorkflowTestsCollector(pytest.Collector):
         self.tempdir = None  # type: Optional[Path]
         self.workflow = None  # type: Optional[Workflow]
 
-        # Attach markers to this node to allow for easier test selection when
-        # running pytest.
-        self.add_marker("workflow")  # To distinguish from other python tests
-        self.add_marker(self.workflow_test.name)
-        for marker in self.workflow_test.markers:
-            self.add_marker(marker)
+        # Attach a marker to this node to distinguish from other python tests
+        self.add_marker("workflow")
+
+        # Attach tags to this node for easier workflow selection
+        self.tags = [self.workflow_test.name] + self.workflow_test.tags
 
     def queue_workflow(self):
         """Creates a temporary directory and add the workflow to the workflow

--- a/src/pytest_workflow/schema.py
+++ b/src/pytest_workflow/schema.py
@@ -179,6 +179,7 @@ class WorkflowTest(object):
     # pylint: disable=too-few-public-methods
 
     def __init__(self, name: str, command: str,
+                 markers: Optional[List[str]],
                  exit_code: int = DEFAULT_EXIT_CODE,
                  stdout: ContentTest = ContentTest(),
                  stderr: ContentTest = ContentTest(),
@@ -199,10 +200,8 @@ class WorkflowTest(object):
         self.exit_code = exit_code
         self.stdout = stdout
         self.stderr = stderr
-        if files:
-            self.files = files
-        else:
-            self.files = []
+        self.files = files if files is not None else []
+        self.markers = markers if markers is not None else []
 
     @classmethod
     def from_schema(cls, schema: dict):
@@ -213,6 +212,7 @@ class WorkflowTest(object):
         return cls(
             name=schema["name"],
             command=schema["command"],
+            markers=schema.get("markers"),
             exit_code=schema.get("exit_code", DEFAULT_EXIT_CODE),
             stdout=ContentTest.from_dict(schema.get("stdout", {})),
             stderr=ContentTest.from_dict(schema.get("stderr", {})),

--- a/src/pytest_workflow/schema.py
+++ b/src/pytest_workflow/schema.py
@@ -179,7 +179,7 @@ class WorkflowTest(object):
     # pylint: disable=too-few-public-methods
 
     def __init__(self, name: str, command: str,
-                 markers: Optional[List[str]],
+                 tags: Optional[List[str]],
                  exit_code: int = DEFAULT_EXIT_CODE,
                  stdout: ContentTest = ContentTest(),
                  stderr: ContentTest = ContentTest(),
@@ -201,7 +201,7 @@ class WorkflowTest(object):
         self.stdout = stdout
         self.stderr = stderr
         self.files = files if files is not None else []
-        self.markers = markers if markers is not None else []
+        self.tags = tags if tags is not None else []
 
     @classmethod
     def from_schema(cls, schema: dict):
@@ -212,7 +212,7 @@ class WorkflowTest(object):
         return cls(
             name=schema["name"],
             command=schema["command"],
-            markers=schema.get("markers"),
+            tags=schema.get("tags"),
             exit_code=schema.get("exit_code", DEFAULT_EXIT_CODE),
             stdout=ContentTest.from_dict(schema.get("stdout", {})),
             stderr=ContentTest.from_dict(schema.get("stderr", {})),

--- a/src/pytest_workflow/schema/schema.json
+++ b/src/pytest_workflow/schema/schema.json
@@ -10,8 +10,8 @@
         "description": "Name of the test",
         "type": "string"
       },
-      "markers": {
-        "description": "Markers for the workflow test",
+      "tags": {
+        "description": "Tags for the workflow test",
         "type": "array",
         "items": {
           "type": "string"

--- a/src/pytest_workflow/schema/schema.json
+++ b/src/pytest_workflow/schema/schema.json
@@ -10,6 +10,13 @@
         "description": "Name of the test",
         "type": "string"
       },
+      "markers": {
+        "description": "Markers for the workflow test",
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
       "command": {
         "description": "The command that is run for the workflow",
         "type": "string"

--- a/tests/test_markers.py
+++ b/tests/test_markers.py
@@ -1,0 +1,51 @@
+# Copyright (C) 2018 Leiden University Medical Center
+# This file is part of pytest-workflow
+#
+# pytest-workflow is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# pytest-workflow is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with pytest-workflow.  If not, see <https://www.gnu.org/licenses/
+
+import textwrap
+
+import pytest
+
+MARKER_TESTS = textwrap.dedent("""\
+- name: three
+  command: echo 3
+  markers:
+    - odd
+    - prime
+- name: three again
+  command: echo 3
+  markers:
+    - odd
+    - prime
+    - again
+- name: four
+  command: echo 4
+  markers:
+    - even
+- name: nine
+  command: echo 9
+  markers:
+    - odd
+""")
+
+
+def test_name_marker_with_space(testdir):
+    testdir.makefile(".yml", test_markers=MARKER_TESTS)
+    result = testdir.runpytest("-v", "-m", "three_again").stdout.str()
+    assert "three again" in result
+    assert "four" not in result
+    assert "nine" not in result
+
+

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -49,6 +49,7 @@ def test_workflowtest():
         assert len(tests[0].files) == 1
         assert tests[0].stdout.contains == ["bla"]
         assert tests[0].exit_code == 127
+        assert tests[0].markers == ["simple", "use_echo"]
 
 
 def test_validate_schema_conflicting_keys():

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -49,7 +49,7 @@ def test_workflowtest():
         assert len(tests[0].files) == 1
         assert tests[0].stdout.contains == ["bla"]
         assert tests[0].exit_code == 127
-        assert tests[0].markers == ["simple", "use_echo"]
+        assert tests[0].tags == ["simple", "use_echo"]
 
 
 def test_validate_schema_conflicting_keys():

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -16,36 +16,32 @@
 
 import textwrap
 
-import pytest
-
 MARKER_TESTS = textwrap.dedent("""\
 - name: three
   command: echo 3
-  markers:
+  tags:
     - odd
     - prime
 - name: three again
   command: echo 3
-  markers:
+  tags:
     - odd
     - prime
     - again
 - name: four
   command: echo 4
-  markers:
+  tags:
     - even
 - name: nine
   command: echo 9
-  markers:
+  tags:
     - odd
 """)
 
 
-def test_name_marker_with_space(testdir):
+def test_name_tag_with_space(testdir):
     testdir.makefile(".yml", test_markers=MARKER_TESTS)
-    result = testdir.runpytest("-v", "-m", "three_again").stdout.str()
+    result = testdir.runpytest("-v", "--tag", "three again").stdout.str()
     assert "three again" in result
     assert "four" not in result
     assert "nine" not in result
-
-

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -46,6 +46,7 @@ def test_name_tag_with_space(testdir):
     assert "four" not in result
     assert "nine" not in result
 
+
 def test_name_tag(testdir):
     testdir.makefile(".yml", test_tags=TAG_TESTS)
     result = testdir.runpytest("-v", "--tag", "three").stdout.str()
@@ -54,6 +55,7 @@ def test_name_tag(testdir):
     assert "four" not in result
     assert "nine" not in result
 
+
 def test_category_tag(testdir):
     testdir.makefile(".yml", test_tags=TAG_TESTS)
     result = testdir.runpytest("-v", "--tag", "odd").stdout.str()
@@ -61,6 +63,7 @@ def test_category_tag(testdir):
     assert "three again" in result
     assert "nine" in result
     assert "four" not in result
+
 
 def test_category_tag2(testdir):
     testdir.makefile(".yml", test_tags=TAG_TESTS)

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -16,7 +16,7 @@
 
 import textwrap
 
-MARKER_TESTS = textwrap.dedent("""\
+TAG_TESTS = textwrap.dedent("""\
 - name: three
   command: echo 3
   tags:
@@ -40,8 +40,32 @@ MARKER_TESTS = textwrap.dedent("""\
 
 
 def test_name_tag_with_space(testdir):
-    testdir.makefile(".yml", test_markers=MARKER_TESTS)
+    testdir.makefile(".yml", test_tags=TAG_TESTS)
     result = testdir.runpytest("-v", "--tag", "three again").stdout.str()
     assert "three again" in result
     assert "four" not in result
+    assert "nine" not in result
+
+def test_name_tag(testdir):
+    testdir.makefile(".yml", test_tags=TAG_TESTS)
+    result = testdir.runpytest("-v", "--tag", "three").stdout.str()
+    assert "three" in result
+    assert "three again" not in result
+    assert "four" not in result
+    assert "nine" not in result
+
+def test_category_tag(testdir):
+    testdir.makefile(".yml", test_tags=TAG_TESTS)
+    result = testdir.runpytest("-v", "--tag", "odd").stdout.str()
+    assert "three" in result
+    assert "three again" in result
+    assert "nine" in result
+    assert "four" not in result
+
+def test_category_tag2(testdir):
+    testdir.makefile(".yml", test_tags=TAG_TESTS)
+    result = testdir.runpytest("-v", "--tag", "even").stdout.str()
+    assert "three" not in result
+    assert "three again" not in result
+    assert "four" in result
     assert "nine" not in result

--- a/tests/yamls/valid/dream_file.yaml
+++ b/tests/yamls/valid/dream_file.yaml
@@ -1,5 +1,5 @@
 - name: simple echo
-  markers:
+  tags:
     - "simple"
     - "use_echo"
   files:

--- a/tests/yamls/valid/dream_file.yaml
+++ b/tests/yamls/valid/dream_file.yaml
@@ -1,4 +1,7 @@
 - name: simple echo
+  markers:
+    - "simple"
+    - "use_echo"
   files:
     - path: "log.file"
       md5sum: "e583af1f8b00b53cda87ae9ead880224"


### PR DESCRIPTION
This will make it easier to get functional tests and integration tests separated and run individual workflows without depending on file and folder structure to accomplish these things.

### Checklist
- [x] Pull request details were added to HISTORY.rst
