### PR TITLE
Empty names and commands should not be accepted as this causes bugs

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,11 @@ Changelog
 .. NOTE: This document is user facing. Please word the changes in such a way
 .. that users understand how the changes affect the new version.
 
+Version 1.0.0-dev
+---------------------------
++ Disallow empty ``command`` and ``name`` keys. An empty ``command`` caused
+  pytest-workflow to hang. Empty names are also disallowed.
+
 Version 0.4.0
 ---------------------------
 + Added more information to the manual on how to debug pipelines and use

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ with open("README.rst", "r") as readme_file:
 
 setup(
     name="pytest-workflow",
-    version="0.5.0-dev",
+    version="1.0.0-dev",
     description="A pytest plugin for configuring workflow/pipeline tests "
                 "using YAML files",
     author="Leiden University Medical Center",

--- a/src/pytest_workflow/schema/schema.json
+++ b/src/pytest_workflow/schema/schema.json
@@ -21,7 +21,7 @@
       "name": {
         "description": "Name of the test",
         "type": "string",
-        "$comment": "Name must not be empty",
+        "$comment": "name must not be empty",
         "minLength": 1
       },
       "tags": {
@@ -34,7 +34,7 @@
       "command": {
         "description": "The command that is run for the workflow",
         "type": "string",
-        "$comment": "Command must not be empty",
+        "$comment": "command must not be empty",
         "minLength": 1
       },
       "exit_code": {

--- a/src/pytest_workflow/schema/schema.json
+++ b/src/pytest_workflow/schema/schema.json
@@ -20,7 +20,9 @@
     "properties": {
       "name": {
         "description": "Name of the test",
-        "type": "string"
+        "type": "string",
+        "$comment": "Name must not be empty",
+        "minLength": 1
       },
       "tags": {
         "description": "Tags for the workflow test",
@@ -31,7 +33,9 @@
       },
       "command": {
         "description": "The command that is run for the workflow",
-        "type": "string"
+        "type": "string",
+        "$comment": "Command must not be empty",
+        "minLength": 1
       },
       "exit_code": {
         "description": "The expected exit code",

--- a/src/pytest_workflow/workflow.py
+++ b/src/pytest_workflow/workflow.py
@@ -44,6 +44,8 @@ class Workflow(object):
         :param name: An alias for the workflow. This looks nicer than a printed
         command.
         """
+        if len(command) < 1:
+            raise ValueError("command can not be an empty string")
         self.command = command
         self.name = name
         self.cwd = cwd

--- a/src/pytest_workflow/workflow.py
+++ b/src/pytest_workflow/workflow.py
@@ -44,7 +44,7 @@ class Workflow(object):
         :param name: An alias for the workflow. This looks nicer than a printed
         command.
         """
-        if len(command) < 1:
+        if command == "":
             raise ValueError("command can not be an empty string")
         self.command = command
         self.name = name

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -79,6 +79,18 @@ def test_validate_schema_colliding_names():
     assert error.match("name collision")
 
 
+def test_no_empty_command():
+    with pytest.raises(jsonschema.ValidationError)  as error:
+        validate_schema([dict(name="empty", command="")])
+    assert error.match("command must not be empty")
+
+
+def test_no_empty_name():
+    with pytest.raises(jsonschema.ValidationError)  as error:
+        validate_schema([dict(name="", command="echo nothing")])
+    assert error.match("name must not be empty")
+
+
 CONTAINS_LIST = [
     """
     - name: bla

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -80,13 +80,13 @@ def test_validate_schema_colliding_names():
 
 
 def test_no_empty_command():
-    with pytest.raises(jsonschema.ValidationError)  as error:
+    with pytest.raises(jsonschema.ValidationError) as error:
         validate_schema([dict(name="empty", command="")])
     assert error.match("command must not be empty")
 
 
 def test_no_empty_name():
-    with pytest.raises(jsonschema.ValidationError)  as error:
+    with pytest.raises(jsonschema.ValidationError) as error:
         validate_schema([dict(name="", command="echo nothing")])
     assert error.match("name must not be empty")
 

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -75,3 +75,9 @@ def test_long_log():
         "bash -c 'for i in {1..262144}; do echo \"this is a long log\"; done'")
     workflow.run()
     assert len(workflow.stdout) > 65536
+
+
+def test_empty_command():
+    with pytest.raises(ValueError) as error:
+        Workflow("")
+    error.match("command can not be an empty string")


### PR DESCRIPTION
Running an empty string as command causes pytest-workflow to hang. 
This bug was not investigated. Empty commands are nonsensical anyway, so they are now disallowed in the schema and in the workflow object.
I also disallowed empty names.
### Checklist
- [x] Pull request details were added to HISTORY.rst
