### PR TITLE
More informative failing of content tests

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -9,6 +9,8 @@ Changelog
 
 Version 1.0.0-dev
 ---------------------------
++ When tests of stdout/stderr content or file content fail a more informative
+  error message is given to allow for easier debugging.
 + All workflows now get their own folder within the `same` temporary directory.
   This fixes a bug where if ``basetemp`` was not set, each workflow would get
   its own folder in a separate temp directory. For example running workflows

--- a/src/pytest_workflow/file_tests.py
+++ b/src/pytest_workflow/file_tests.py
@@ -67,7 +67,8 @@ class FileTestCollector(pytest.Collector):
                                                     filepath),
                 content_test=self.filetest,
                 # FileTest inherits from ContentTest. So this is valid.
-                workflow=self.workflow
+                workflow=self.workflow,
+                content_name=str(filepath)
             )]
 
         if self.filetest.md5sum:

--- a/src/pytest_workflow/plugin.py
+++ b/src/pytest_workflow/plugin.py
@@ -239,13 +239,15 @@ class WorkflowTestsCollector(pytest.Collector):
             name="stdout", parent=self,
             content_generator=workflow.stdout_lines,
             content_test=self.workflow_test.stdout,
-            workflow=workflow)]
+            workflow=workflow,
+            content_name="'{0}': stdout".format(self.workflow_test.name))]
 
         tests += [ContentTestCollector(
             name="stderr", parent=self,
             content_generator=workflow.stderr_lines,
             content_test=self.workflow_test.stderr,
-            workflow=workflow)]
+            workflow=workflow,
+            content_name="'{0}': stderr".format(self.workflow_test.name))]
 
         return tests
 

--- a/tests/test_fail_messages.py
+++ b/tests/test_fail_messages.py
@@ -60,7 +60,7 @@ FAILURE_MESSAGE_TESTS = [
           contains:
             - miaow
     """,
-     "'miaow' was not found in content while it should be there"),
+     "moo_file_contains_miaow/moo.txt while it should be there"),
     ("""\
     - name: moo file does not contain moo
       command: bash -c 'echo moo > moo.txt'
@@ -69,7 +69,7 @@ FAILURE_MESSAGE_TESTS = [
           must_not_contain:
             - moo
     """,
-     "'moo' was found in content while it should not be there"),
+     "moo_file_does_not_contain_moo/moo.txt while it should not be there"),
     ("""\
     - name: echo miaow
       command: echo moo
@@ -77,7 +77,7 @@ FAILURE_MESSAGE_TESTS = [
         contains:
           - miaow
     """,
-     "'miaow' was not found in stdout while it should be there"),
+     "'miaow' was not found in 'echo miaow': stdout while it should be there"),
     ("""\
     - name: echo does not contain moo
       command: echo moo
@@ -85,7 +85,8 @@ FAILURE_MESSAGE_TESTS = [
         must_not_contain:
           - moo
     """,
-     "moo' was found in stdout while it should not be there"),
+     "moo' was found in 'echo does not contain moo': stdout while "
+     "it should not be there"),
     ("""\
     - name: fail_test
       command: grep
@@ -93,7 +94,8 @@ FAILURE_MESSAGE_TESTS = [
         contains:
           - "No arguments?"
     """,
-     "'No arguments?' was not found in stderr while it should be there"),
+     "'No arguments?' was not found in 'fail_test': stderr "
+     "while it should be there"),
     ("""\
     - name: fail_test
       command: grep
@@ -101,7 +103,8 @@ FAILURE_MESSAGE_TESTS = [
         must_not_contain:
           - "grep --help"
     """,
-     "'grep --help' was found in stderr while it should not be there")
+     "'grep --help' was found in 'fail_test': stderr while "
+     "it should not be there")
 ]  # type: List[Tuple[str,str]]
 
 


### PR DESCRIPTION
When tests failed previously checking content in files it would report: 'some string' not found in content.

Now it reports: 'some string' not found in path/to/file.

Also 'some string not found in stdout

was changed to 'some string' not found in 'name of workflow': stdout.

So now if content checks fail the message is much more informative.

### Checklist
- [ ] Pull request details were added to HISTORY.rst
