### PR TITLE
Stream logs to files.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -12,6 +12,12 @@ Version 1.0.0-dev
 Lots of small fixes that improve the usability of pytest-workflow are included
 in version 1.0.0.
 
++ ``stdout`` and ``stderr`` of workflows are now streamed to a file instead of
+  being kept in memory. This means you can check the progress of a workflow by
+  running ``tail -f <stdout or stderr>``. The location of ``stdout`` and
+  ``stderr`` is now reported at the start of each worflow. If the
+  ``--keep-workflow-wd`` is not set the ``stdout`` and ``stderr`` files will be
+  deleted with the rest of the workflow files.
 + The log reports now when a workflow is starting, instead of when it is added
   to the queue. This makes it easier to see which workflows are currently
   running and if you forgot to use the ``--workflow-threads`` or ``--wt`` flag.

--- a/README.rst
+++ b/README.rst
@@ -44,10 +44,10 @@ Run ``pytest`` from an environment with pytest-workflow installed.
 Pytest will automatically gather files in the ``tests`` directory starting with
 ``test`` and ending in ``.yaml`` or ``.yml``.
 
-For debugging pipelines running ``pytest -v --keep-workflow-wd`` is
-recommended. This will save the logs and the workflow directory so it is
-possible to check where the pipeline crashed. It will also give a better
-overview of succeeded and failed tests.
+For debugging pipelines using the ``--keep-workflow-wd`` flag  is
+recommended. This will keep the workflow directory and logs after the test run
+so it is possible to check where the pipeline crashed. The ``-v`` flag can come
+in handy as well as it gives a complete overview of succeeded and failed tests.
 
 Below is an example of a YAML file that defines a test:
 

--- a/README.rst
+++ b/README.rst
@@ -44,6 +44,10 @@ Run ``pytest`` from an environment with pytest-workflow installed.
 Pytest will automatically gather files in the ``tests`` directory starting with
 ``test`` and ending in ``.yaml`` or ``.yml``.
 
+To check the progress of a workflow while it is running you can use ``tail -f``
+on the ``stdout`` or ``stderr`` file of the workflow. The locations of these
+files are reported in the log as soon as a workflow is started.
+
 For debugging pipelines using the ``--keep-workflow-wd`` flag  is
 recommended. This will keep the workflow directory and logs after the test run
 so it is possible to check where the pipeline crashed. The ``-v`` flag can come

--- a/docs/running_pytest_workflow.rst
+++ b/docs/running_pytest_workflow.rst
@@ -7,13 +7,12 @@ Pytest will automatically gather files in the ``tests`` directory starting with
 ``test`` and ending in ``.yaml`` or ``.yml``.
 
 The workflows are run automatically. Each workflow gets its own temporary
-directory to run. These directories are cleaned up after the tests are
-completed. If you wish to inspect the output of a failing workflow you can use
-the ``--keep-workflow-wd`` flag to disable cleanup. This will also make sure
-the logs of the pipeline are saved in the temporary directory. When
-``--keep-workflow-wd`` is set, the paths to the logs and the temporary
-directory are reported in pytest's output. The `--keep-workflow-wd`` flag is
-highly recommended when debugging pipelines.
+directory to run. The ``stdout`` and ``stderr`` of the workflow command are
+also saved to this directory. The temporary directories are cleaned up after
+the tests are completed. If you wish to inspect the output of a failing
+workflow you can use the ``--keep-workflow-wd`` flag to disable cleanup. This
+will also make sure the logs of the pipeline are not deleted. The
+``--keep-workflow-wd`` flag is highly recommended when debugging pipelines.
 
 If you wish to change the temporary directory in which the workflows are run
 use ``--basetemp <dir>`` to change pytest's base temp directory.

--- a/docs/running_pytest_workflow.rst
+++ b/docs/running_pytest_workflow.rst
@@ -32,6 +32,10 @@ To run multiple workflows simultaneously you can use
 of workflows that can be run simultaneously. This will speed up things if
 you have enough resources to process these workflows simultaneously.
 
+To check the progress of a workflow while it is running you can use ``tail -f``
+on the ``stdout`` or ``stderr`` file of the workflow. The locations of these
+files are reported in the log as soon as a workflow is started.
+
 Running specific workflows
 ----------------------------
 To run a specific workflow use the ``--tag`` flag. Each workflow is tagged with

--- a/src/pytest_workflow/content_tests.py
+++ b/src/pytest_workflow/content_tests.py
@@ -22,7 +22,7 @@ once."""
 
 import threading
 from pathlib import Path
-from typing import Optional, Iterable, List, Set
+from typing import Iterable, List, Optional, Set
 
 import pytest
 

--- a/src/pytest_workflow/content_tests.py
+++ b/src/pytest_workflow/content_tests.py
@@ -119,11 +119,8 @@ class ContentTestCollector(pytest.Collector):
         self.content_name = content_name or str(filepath)
 
     def find_strings(self):
-        """Find the strings that are looked for in the given content
-        The content_generator function shines here. It only starts looking
-        for lines of text AFTER the workflow is finished. So that is why a
-        function is needed here and not just a variable containing lines of
-        text.
+        """Find the strings that are looked for in the given file
+
         When a file we test is not produced, we save the FileNotFoundError so
         we can give an accurate repr_failure."""
         self.workflow.wait()
@@ -190,7 +187,7 @@ class ContentTestItem(pytest.Item):
 
     def runtest(self):
         """Only after a workflow is finished the contents of files and logs are
-        read. The ContentTestCollector parent reads each file/log once. This is
+        read. The ContentTestCollector parent reads each file once. This is
         done in its thread. We wait for this thread to complete. Then we check
         all the found strings in the parent.
         This way we do not have to read each file one time per ContentTestItem

--- a/src/pytest_workflow/content_tests.py
+++ b/src/pytest_workflow/content_tests.py
@@ -22,7 +22,7 @@ once."""
 
 import threading
 from pathlib import Path
-from typing import Callable, Iterable, List, Set
+from typing import Iterable, List, Set
 
 import pytest
 
@@ -90,7 +90,7 @@ def file_to_string_generator(filepath: Path) -> Iterable[str]:
 
 class ContentTestCollector(pytest.Collector):
     def __init__(self, name: str, parent: pytest.Collector,
-                 content_generator: Callable[[], Iterable[str]],
+                 filepath: Path,
                  content_test: ContentTest,
                  content_name: str,
                  workflow: Workflow):
@@ -113,7 +113,7 @@ class ContentTestCollector(pytest.Collector):
         # pylint: disable=too-many-arguments
         # it is still only 5 not counting self.
         super().__init__(name, parent=parent)
-        self.content_generator = content_generator
+        self.filepath = filepath
         self.content_test = content_test
         self.workflow = workflow
         self.found_strings = None
@@ -138,7 +138,7 @@ class ContentTestCollector(pytest.Collector):
         try:
             self.found_strings = check_content(
                 strings=strings_to_check,
-                text_lines=self.content_generator())
+                text_lines=file_to_string_generator(self.filepath))
         except FileNotFoundError:
             self.file_not_found = True
 

--- a/src/pytest_workflow/content_tests.py
+++ b/src/pytest_workflow/content_tests.py
@@ -22,7 +22,7 @@ once."""
 
 import threading
 from pathlib import Path
-from typing import Iterable, List, Set
+from typing import Optional, Iterable, List, Set
 
 import pytest
 
@@ -92,26 +92,20 @@ class ContentTestCollector(pytest.Collector):
     def __init__(self, name: str, parent: pytest.Collector,
                  filepath: Path,
                  content_test: ContentTest,
-                 content_name: str,
-                 workflow: Workflow):
+                 workflow: Workflow,
+                 content_name: Optional[str] = None):
         """
         Creates a content test collector
         :param name: Name of the thing which contents are tested
         :param parent: a pytest.Collector object
-        :param content_generator: a function that should return the content as
-        lines. This function is a placeholder for the content itself. In other
-        words: instead of passing the contents of a file directly to the
-        ContentTestCollector, you pass a function that when called will return
-        the contents. This allows the pytest collection phase to finish before
-        the file is read. This is useful because the workflows are run after
-        the collection phase.
+        :param filepath: the file that contains the content
         :param content_test: a ContentTest object.
         :param workflow: the workflow is running.
         :param content_name: The name of the content that will be displayed if
-        the test fails.
+        the test fails. Defaults to filepath.
         """
         # pylint: disable=too-many-arguments
-        # it is still only 5 not counting self.
+        # Cannot think of a better way to do this.
         super().__init__(name, parent=parent)
         self.filepath = filepath
         self.content_test = content_test
@@ -122,7 +116,7 @@ class ContentTestCollector(pytest.Collector):
         # content can not be checked. We save FileNotFoundErrors in this
         # boolean.
         self.file_not_found = False
-        self.content_name = content_name
+        self.content_name = content_name or str(filepath)
 
     def find_strings(self):
         """Find the strings that are looked for in the given content

--- a/src/pytest_workflow/file_tests.py
+++ b/src/pytest_workflow/file_tests.py
@@ -15,13 +15,12 @@
 # along with pytest-workflow.  If not, see <https://www.gnu.org/licenses/
 
 """All tests for workflow files"""
-import functools
 import hashlib
 from pathlib import Path
 
 import pytest
 
-from .content_tests import ContentTestCollector, file_to_string_generator
+from .content_tests import ContentTestCollector
 from .schema import FileTest
 from .workflow import Workflow
 
@@ -63,8 +62,7 @@ class FileTestCollector(pytest.Collector):
             tests += [ContentTestCollector(
                 name="content",
                 parent=self,
-                content_generator=functools.partial(file_to_string_generator,
-                                                    filepath),
+                filepath=filepath,
                 content_test=self.filetest,
                 # FileTest inherits from ContentTest. So this is valid.
                 workflow=self.workflow,

--- a/src/pytest_workflow/file_tests.py
+++ b/src/pytest_workflow/file_tests.py
@@ -65,9 +65,7 @@ class FileTestCollector(pytest.Collector):
                 filepath=filepath,
                 content_test=self.filetest,
                 # FileTest inherits from ContentTest. So this is valid.
-                workflow=self.workflow,
-                content_name=str(filepath)
-            )]
+                workflow=self.workflow)]
 
         if self.filetest.md5sum:
             tests += [FileMd5(

--- a/src/pytest_workflow/plugin.py
+++ b/src/pytest_workflow/plugin.py
@@ -15,7 +15,6 @@
 # along with pytest-workflow.  If not, see <https://www.gnu.org/licenses/
 
 """core functionality of pytest-workflow plugin"""
-import functools
 import shutil
 import tempfile
 import warnings
@@ -27,7 +26,7 @@ import pytest
 import yaml
 
 from . import replace_whitespace
-from .content_tests import ContentTestCollector, file_to_string_generator
+from .content_tests import ContentTestCollector
 from .file_tests import FileTestCollector
 from .schema import WorkflowTest, workflow_tests_from_schema
 from .workflow import Workflow, WorkflowQueue
@@ -240,16 +239,14 @@ class WorkflowTestsCollector(pytest.Collector):
 
         tests += [ContentTestCollector(
             name="stdout", parent=self,
-            content_generator=functools.partial(file_to_string_generator,
-                                                workflow.stdout_file),
+            filepath=workflow.stdout_file,
             content_test=self.workflow_test.stdout,
             workflow=workflow,
             content_name="'{0}': stdout".format(self.workflow_test.name))]
 
         tests += [ContentTestCollector(
             name="stderr", parent=self,
-            content_generator=functools.partial(file_to_string_generator,
-                                                workflow.stderr_file),
+            filepath=workflow.stderr_file,
             content_test=self.workflow_test.stderr,
             workflow=workflow,
             content_name="'{0}': stderr".format(self.workflow_test.name))]

--- a/src/pytest_workflow/workflow.py
+++ b/src/pytest_workflow/workflow.py
@@ -105,8 +105,8 @@ class Workflow(object):
             time.sleep(wait_interval_secs)
             wait_time_secs += wait_interval_secs
 
-        # Stdout and stderr are written to files. So popen.wait() gives no
-        # errors with long stderr or stdout.
+        # Stdout and stderr are written to files. So popen.wait() does not
+        # block process completion with long stderr or stdout.
         self._popen.wait()
 
     @property

--- a/src/pytest_workflow/workflow.py
+++ b/src/pytest_workflow/workflow.py
@@ -53,6 +53,10 @@ class Workflow(object):
         # for emptiness.
         self.name = name or command.split()[0]
         self.cwd = cwd or Path()
+        # For long running workflows it is best to save the stdout and stderr
+        # to a file which can be checked with ``tail -f``.
+        # stdout and stderr will be written to a tempfile if no CWD is given
+        # to prevent clutter created when testing.
         self.stdout_file = (Path(tempfile.NamedTemporaryFile().name)
                             if cwd is None
                             else self.cwd / Path("log.out"))

--- a/src/pytest_workflow/workflow.py
+++ b/src/pytest_workflow/workflow.py
@@ -32,8 +32,7 @@ from typing import Optional
 
 
 class Workflow(object):
-    # pylint: disable=too-many-instance-attributes
-    # Is there a better way of doing things, as pylint suggests?
+
     def __init__(self,
                  command: str,
                  cwd: Optional[Path] = None,

--- a/src/pytest_workflow/workflow.py
+++ b/src/pytest_workflow/workflow.py
@@ -156,7 +156,7 @@ class WorkflowQueue(queue.Queue):
 
     # Queue processing with workers example taken from
     # https://docs.python.org/3.5/library/queue.html?highlight=queue#queue.Queue.join  # noqa
-    def process(self, number_of_threads: int = 1, save_logs: bool = False):
+    def process(self, number_of_threads: int = 1):
         """
         Processes the workflow queue with a number of threads
         :param number_of_threads: The number of threads
@@ -165,18 +165,16 @@ class WorkflowQueue(queue.Queue):
         """
         threads = []
         for _ in range(number_of_threads):
-            thread = threading.Thread(target=self.worker, args=(save_logs,))
+            thread = threading.Thread(target=self.worker)
             thread.start()
             threads.append(thread)
         self.join()
         for thread in threads:
             thread.join()
 
-    def worker(self, save_logs: bool = False):
+    def worker(self):
         """
         Run workflows until the queue is empty
-        :param save_logs: Whether to save the logs of the workflows that have
-        run
         """
         while True:
             try:
@@ -196,10 +194,7 @@ class WorkflowQueue(queue.Queue):
                 self.task_done()
                 # Some reporting
                 print("'{0}' done.".format(workflow.name))
-                if save_logs:
-                    log_err = workflow.stderr_to_file()
-                    log_out = workflow.stdout_to_file()
-                    print("'{0}' stdout saved in: {1}".format(
-                        workflow.name or workflow.command, str(log_out)))
-                    print("'{0}' stderr saved in: {1}".format(
-                        workflow.name or workflow.command, str(log_err)))
+                print("'{0}' stdout saved in: {1}".format(
+                    workflow.name, str(workflow.stdout_file)))
+                print("'{0}' stderr saved in: {1}".format(
+                    workflow.name, str(workflow.stderr_file)))

--- a/src/pytest_workflow/workflow.py
+++ b/src/pytest_workflow/workflow.py
@@ -164,8 +164,6 @@ class WorkflowQueue(queue.Queue):
         """
         Processes the workflow queue with a number of threads
         :param number_of_threads: The number of threads
-        :param save_logs: Whether to save the logs of the workflows that have
-        run
         """
         threads = []
         for _ in range(number_of_threads):

--- a/src/pytest_workflow/workflow.py
+++ b/src/pytest_workflow/workflow.py
@@ -28,7 +28,7 @@ import tempfile
 import threading
 import time
 from pathlib import Path
-from typing import List, Optional  # noqa: F401  # used for typing
+from typing import Optional  # noqa: F401  # used for typing
 
 
 class Workflow(object):
@@ -185,16 +185,16 @@ class WorkflowQueue(queue.Queue):
                 break
             else:
                 print(
-                    "start '{name}' with command '{command}' in '{dir}'"
+                    "start '{name}' with command '{command}' in '{dir}'. "
+                    "stdout: '{stdout_file}'. "
+                    "stderr: '{stderr_file}'."
                     .format(
                         name=workflow.name,
                         command=workflow.command,
-                        dir=workflow.cwd))
+                        dir=workflow.cwd,
+                        stdout_file=workflow.stdout_file,
+                        stderr_file=workflow.stderr_file))
                 workflow.run()
                 self.task_done()
                 # Some reporting
                 print("'{0}' done.".format(workflow.name))
-                print("'{0}' stdout saved in: {1}".format(
-                    workflow.name, str(workflow.stdout_file)))
-                print("'{0}' stderr saved in: {1}".format(
-                    workflow.name, str(workflow.stderr_file)))

--- a/src/pytest_workflow/workflow.py
+++ b/src/pytest_workflow/workflow.py
@@ -28,7 +28,7 @@ import tempfile
 import threading
 import time
 from pathlib import Path
-from typing import Optional  # noqa: F401  # used for typing
+from typing import Optional
 
 
 class Workflow(object):

--- a/src/pytest_workflow/workflow.py
+++ b/src/pytest_workflow/workflow.py
@@ -56,12 +56,16 @@ class Workflow(object):
         # to a file which can be checked with ``tail -f``.
         # stdout and stderr will be written to a tempfile if no CWD is given
         # to prevent clutter created when testing.
-        self.stdout_file = (Path(tempfile.NamedTemporaryFile().name)
-                            if cwd is None
-                            else self.cwd / Path("log.out"))
-        self.stderr_file = (Path(tempfile.NamedTemporaryFile().name)
-                            if cwd is None
-                            else self.cwd / Path("log.err"))
+        self.stdout_file = (
+            Path(tempfile.NamedTemporaryFile(prefix=self.name,
+                                             suffix=".out").name)
+            if cwd is None
+            else self.cwd / Path("log.out"))
+        self.stderr_file = (
+            Path(tempfile.NamedTemporaryFile(prefix=self.name,
+                                             suffix=".err").name)
+            if cwd is None
+            else self.cwd / Path("log.err"))
         self._popen = None  # type: Optional[subprocess.Popen]
         self.start_lock = threading.Lock()
 

--- a/src/pytest_workflow/workflow.py
+++ b/src/pytest_workflow/workflow.py
@@ -94,7 +94,13 @@ class Workflow(object):
 
     def wait(self, timeout_secs: Optional[float] = None,
              wait_interval_secs: float = 0.01):
-        """Waits for the workflow to complete"""
+        """Waits for the workflow to complete
+        :param timeout_secs: how many seconds should be waited on a workflow
+        the total wait time = wait_to_start_time + run_time. This is set to
+        None by default as it is very hard to predict how long a workflow runs
+        and how long it has to wait on other workflows before starting.
+        :param wait_interval_secs: check interval secs if a workflow is started
+        """
         wait_time = 0.0
         while self._popen is None:
             # This piece of code checks if a workflow has started yet. If

--- a/tests/test_temp_directory.py
+++ b/tests/test_temp_directory.py
@@ -22,17 +22,10 @@ from pathlib import Path
 from .test_success_messages import SIMPLE_ECHO
 
 
-def test_log_messages(testdir):
-    testdir.makefile(".yml", test=SIMPLE_ECHO)
-    result = testdir.runpytest("-v", "--keep-workflow-wd")
-    assert "'simple echo' stdout saved in: " in result.stdout.str()
-    assert "'simple echo' stderr saved in: " in result.stdout.str()
-
-
 def test_directory_kept(testdir):
     testdir.makefile(".yml", test=SIMPLE_ECHO)
     result = testdir.runpytest("-v", "--keep-workflow-wd")
-    working_dir = re.search(r"with command 'echo moo' in '(.*)'",
+    working_dir = re.search(r"with command 'echo moo' in '([\w\/_-]*)'",
                             result.stdout.str()).group(1)
     assert Path(working_dir).exists()
     assert Path(working_dir / Path("log.out")).exists()
@@ -42,7 +35,7 @@ def test_directory_kept(testdir):
 def test_directory_not_kept(testdir):
     testdir.makefile(".yml", test=SIMPLE_ECHO)
     result = testdir.runpytest("-v")
-    working_dir = re.search(r"with command 'echo moo' in '(.*)'",
+    working_dir = re.search(r"with command 'echo moo' in '([\w\/_-]*)'",
                             result.stdout.str()).group(1)
     assert not Path(working_dir).exists()
 
@@ -51,7 +44,12 @@ def test_basetemp_correct(testdir):
     testdir.makefile(".yml", test=SIMPLE_ECHO)
     tempdir = tempfile.mkdtemp()
     result = testdir.runpytest("-v", "--basetemp", tempdir)
-    assert str(tempdir) in result.stdout.str()
+    message = ("start 'simple echo' with command 'echo moo' in "
+               "'{tempdir}/simple_echo'. "
+               "stdout: '{tempdir}/simple_echo/log.out'. "
+               "stderr: '{tempdir}/simple_echo/log.err'."
+               ).format(tempdir=str(tempdir))
+    assert message in result.stdout.str()
 
 
 def test_basetemp_can_be_used_twice(testdir):

--- a/tests/test_temp_directory.py
+++ b/tests/test_temp_directory.py
@@ -29,13 +29,6 @@ def test_log_messages(testdir):
     assert "'simple echo' stderr saved in: " in result.stdout.str()
 
 
-def test_not_log_messages(testdir):
-    testdir.makefile(".yml", test=SIMPLE_ECHO)
-    result = testdir.runpytest("-v")
-    assert "'simple echo' stdout saved in: " not in result.stdout.str()
-    assert "'simple echo' stderr saved in: " not in result.stdout.str()
-
-
 def test_directory_kept(testdir):
     testdir.makefile(".yml", test=SIMPLE_ECHO)
     result = testdir.runpytest("-v", "--keep-workflow-wd")

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -46,11 +46,8 @@ def test_stderr():
 
 def test_wait_timeout():
     workflow = Workflow("echo moo")
-    workflow.wait_timeout_secs = 0.1
-    workflow.wait_interval_secs = 0.01
     with pytest.raises(ValueError) as error:
-        workflow.wait()
-    assert math.isclose(workflow.wait_time_secs, 0.11)
+        workflow.wait(wait_timeout_secs=0.1, wait_interval_secs=0.01)
     assert error.match(
         "Waiting on a workflow that has not started within the last 0.1 "
         "seconds"


### PR DESCRIPTION
This streams the logs to a file. This means the progress of a running workflow can be checked by running `tail -f` on the stdout and stderr file. This is very useful when testing workflow. 

This uses _less_ code. The location of the stdout and stderr are now always reported when the workflow is started. This removes some logic from the code. Stdout and stderr are files now, which means their content can be tested just like other files, this allows reuse of code, and removal of log specific code.

EDIT: I realized that we had a lock in place because the wait command did not only wait, it also wrote the stderr and stdout to the object variables. Since that functionality is not necessary anymore, the wait command now only waits. This means the locks can be dropped and things can be much simpler.

EDIT2: I also fixed `workflow.wait()`. The given timeout now applies also to the running workflows. The function was sort of broken before. It waited for the workflow to start within the timeout, but if the workflow was started on time it could run indefinitely. A test was added to check if it correctly waits.

### Checklist
- [x] Pull request details were added to HISTORY.rst
