### PR TITLE
Enable custom tests on workflow runs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,3 +54,4 @@ matrix:
         - conda config --add channels conda-forge
         - conda create -n my_env cromwell
         - source activate my_env
+        - pip install --upgrade pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,5 +52,5 @@ matrix:
         - conda config --add channels defaults
         - conda config --add channels bioconda
         - conda config --add channels conda-forge
-        - conda create -n my_env cromwell ca-certificates
+        - conda create -n my_env cromwell tox  # Install tox for good integration within the conda env.
         - source activate my_env

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,5 @@ matrix:
         - conda config --add channels defaults
         - conda config --add channels bioconda
         - conda config --add channels conda-forge
-        - conda create -n my_env cromwell
+        - conda create -n my_env cromwell ca-certificates
         - source activate my_env
-        - pip install --upgrade pip

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,10 @@ Changelog
 .. NOTE: This document is user facing. Please word the changes in such a way
 .. that users understand how the changes affect the new version.
 
+version 1.1.0-dev
+---------------------------
++ Enabled custom tests on workflow files.
+
 Version 1.0.0
 ---------------------------
 Lots of small fixes that improve the usability of pytest-workflow are included

--- a/README.rst
+++ b/README.rst
@@ -69,7 +69,8 @@ Below is an example of a YAML file that defines a test:
 This will run ``touch test.file`` and check afterwards if a file with path:
 ``test.file`` is present. It will also check if the ``command`` has exited
 with exit code ``0``, which is the only default test that is run. Testing
-workflows that exit with another exit code is also possible.
+workflows that exit with another exit code is also possible. Several other
+predefined tests as well as custom tests are possible.
 
 Documentation for more advanced use cases can be found on our
 `readthedocs page <https://pytest-workflow.readthedocs.io/>`_.

--- a/docs/writing_tests.rst
+++ b/docs/writing_tests.rst
@@ -93,7 +93,8 @@ workflow.
 The ``@pytest.mark.workflow(name='files containing numbers')`` marks the test
 as belonging to a workflow named 'files containing numbers'. The mark can also
 be written without the explicit ``name`` key as ``@pytest.mark.workflow('files
-containing nummbers')``.
+containing nummbers')``. This test will only run if the workflow 'files
+containing numbers' has run.
 
 ``workflow_dir`` is a fixture. It does not work without a
 ``pytest.mark.workflow('workflow_name')`` mark.  This is a

--- a/docs/writing_tests.rst
+++ b/docs/writing_tests.rst
@@ -78,9 +78,12 @@ workflow.
 
 .. code-block:: python
 
+    import pathlib
+    import pytest
+
     @pytest.mark.workflow(name='files containing numbers')
     def test_div_by_three(workflow_dir):
-        number_file = workflow_dir / Path("123.txt")
+        number_file = workflow_dir / pathlib.Path("123.txt")
 
         with number_file.open('rt') as file_h:
             number_file_content = file_h.read()
@@ -88,10 +91,14 @@ workflow.
         assert int(number_file_content) % 3 == 0
 
 The ``@pytest.mark.workflow(name='files containing numbers')`` marks the test
-as belonging to a workflow named 'files containing numbers'. This enables the
-use of a ``workflow_dir`` fixture. This is a
+as belonging to a workflow named 'files containing numbers'. The mark can also
+be written without the explicit ``name`` key as ``@pytest.mark.workflow('files
+containing nummbers')``.
+
+``workflow_dir`` is a fixture. It does not work without a
+``pytest.mark.workflow('workflow_name')`` mark.  This is a
 `pathlib.Path <https://docs.python.org/3/library/pathlib.html>`_ object that
-points to the folder where the workflow was executed. This allows writing of
+points to the folder where the named workflow was executed. This allows writing of
 advanced python tests for each file produced by the workflow.
 
 .. container:: note

--- a/docs/writing_tests.rst
+++ b/docs/writing_tests.rst
@@ -2,6 +2,9 @@
 Writing tests with pytest-workflow
 ==================================
 
+Getting started
+---------------
+
 In order to write tests that are discoverable by the plugin you need to
 complete the following steps.
 
@@ -23,7 +26,8 @@ This will run ``touch test.file`` and check afterwards if a file with path:
 with exit code ``0``, which is the only default test that is run. Testing
 workflows that exit with another exit code is also possible.
 
-A more advanced example:
+Test options
+------------
 
 .. code-block:: yaml
 
@@ -65,3 +69,32 @@ A more advanced example:
 
 
 The above YAML file contains all the possible options for a workflow test.
+
+Writing custom tests
+--------------------
+
+Pytest-workflow provides a way to run custom tests on files produced by a
+workflow.
+
+.. code-block:: python
+
+    @pytest.mark.workflow(name='files containing numbers')
+    def test_div_by_three(workflow_dir):
+        number_file = workflow_dir / Path("123.txt")
+
+        with number_file.open('rt') as file_h:
+            number_file_content = file_h.read()
+
+        assert int(number_file_content) % 3 == 0
+
+The ``@pytest.mark.workflow(name='files containing numbers')`` marks the test
+as belonging to a workflow named 'files containing numbers'. This enables the
+use of a ``workflow_dir`` fixture. This is a
+`pathlib.Path <https://docs.python.org/3/library/pathlib.html>`_ object that
+points to the folder where the workflow was executed. This allows writing of
+advanced python tests for each file produced by the workflow.
+
+.. container:: note
+
+    NOTE: stdout and stderr are available as files in the root of the
+    ``workflow_dir`` as ``log.out`` and ``log.err`` respectively.

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,2 @@
+[mypy]
+ignore_missing_imports = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,2 +1,3 @@
 [mypy]
+# This ignores a lot of errors that are a huge headache to fix.
 ignore_missing_imports = True

--- a/src/pytest_workflow/content_tests.py
+++ b/src/pytest_workflow/content_tests.py
@@ -46,7 +46,7 @@ def check_content(strings: List[str],
 
     # Create two sets. By default all strings are not found.
     strings_to_check = set(strings)
-    found_strings = set()
+    found_strings = set()  # type: Set[str]
 
     for line in text_lines:
         # Break the loop if all strings are found
@@ -88,7 +88,7 @@ def file_to_string_generator(filepath: Path) -> Iterable[str]:
                  if filepath.suffix == ".gz" else
                  filepath.open)
     # Use 'rt' here explicitly as opposed to 'rb'
-    with file_open(mode='rt') as file_handler:
+    with file_open(mode='rt') as file_handler:  # type: ignore  # mypy goes crazy here otherwise  # noqa: E501
         for line in file_handler:
             yield line
 

--- a/src/pytest_workflow/plugin.py
+++ b/src/pytest_workflow/plugin.py
@@ -157,7 +157,7 @@ def pytest_collection_modifyitems(config: PytestConfig,
                     workflow_name = marker.args[0]
                     # Make sure a marker with name is added anyway for the
                     # fixture lookup.
-                    item.add_marker(pytest.mark.workflow(name=workflow_name))
+                    marker.kwargs['name'] = workflow_name
                 except IndexError:
                     raise ValueError("A workflow name should be defined in the"
                                      "workflow marker of {0}".format(item.name)

--- a/src/pytest_workflow/plugin.py
+++ b/src/pytest_workflow/plugin.py
@@ -174,11 +174,11 @@ def workflow_dir(request: SubRequest):
     """Returns the workflow_dir of the workflow named in the mark. This fixture
     is only provided for tests that are marked with the workflow mark."""
 
-    workflow_temp_dir = request.config.workflow_temp_dir
     # request.node refers to the node that has the mark. This is a pytest.Node
     marker = request.node.get_closest_marker(name="workflow")
 
     if marker is not None:
+        workflow_temp_dir = request.config.workflow_temp_dir
         workflow_name = marker.kwargs['name']
         return workflow_temp_dir / Path(replace_whitespace(workflow_name))
     else:

--- a/src/pytest_workflow/plugin.py
+++ b/src/pytest_workflow/plugin.py
@@ -149,7 +149,19 @@ def pytest_collection_modifyitems(config: PytestConfig,
     for item in items:
         marker = item.get_closest_marker(name="workflow")  # type: Optional[MarkDecorator] # noqa: E501
         if marker is not None:
-            workflow_name = marker.kwargs['name']
+            try:
+                workflow_name = marker.kwargs['name']
+            except KeyError:
+                # If name key is not defined use the first arg.
+                try:
+                    workflow_name = marker.args[0]
+                    # Make sure a marker with name is added anyway for the
+                    # fixture lookup.
+                    item.add_marker(pytest.mark.workflow(name=workflow_name))
+                except IndexError:
+                    raise ValueError("A workflow name should be defined in the"
+                                     "workflow marker of {0}".format(item.name)
+                                     )
             if workflow_name not in config.executed_workflows:
                 skip_marker = pytest.mark.skip(
                     reason="'{0}' has not run.".format(workflow_name))

--- a/src/pytest_workflow/plugin.py
+++ b/src/pytest_workflow/plugin.py
@@ -159,9 +159,10 @@ def pytest_collection_modifyitems(config: PytestConfig,
                     # fixture lookup.
                     marker.kwargs['name'] = workflow_name
                 except IndexError:
-                    raise ValueError("A workflow name should be defined in the"
-                                     "workflow marker of {0}".format(item.name)
-                                     )
+                    raise ValueError(
+                        "A workflow name should be defined in the "
+                        "workflow marker of {0}".format(item.name)
+                        )
             if workflow_name not in config.executed_workflows:
                 skip_marker = pytest.mark.skip(
                     reason="'{0}' has not run.".format(workflow_name))

--- a/src/pytest_workflow/plugin.py
+++ b/src/pytest_workflow/plugin.py
@@ -156,6 +156,19 @@ def pytest_collection_modifyitems(config: PytestConfig,
                 item.add_marker(skip_marker)
 
 
+def pytest_runtestloop(session: pytest.Session):
+    """This runs after collection, but before the tests."""
+    session.config.workflow_queue.process(
+        session.config.getoption("workflow_threads")
+    )
+
+
+def pytest_sessionfinish(session: pytest.Session):
+    if not session.config.getoption("keep_workflow_wd"):
+        for tempdir in session.config.workflow_cleanup_dirs:
+            shutil.rmtree(str(tempdir))
+
+
 @pytest.fixture()
 def workflow_dir(request: SubRequest):
     """Returns the workflow_dir of the workflow named in the mark. This fixture
@@ -171,19 +184,6 @@ def workflow_dir(request: SubRequest):
     else:
         raise ValueError("workflow_dir can only be requested in tests marked"
                          " with the workflow mark.")
-
-
-def pytest_runtestloop(session: pytest.Session):
-    """This runs after collection, but before the tests."""
-    session.config.workflow_queue.process(
-        session.config.getoption("workflow_threads")
-    )
-
-
-def pytest_sessionfinish(session: pytest.Session):
-    if not session.config.getoption("keep_workflow_wd"):
-        for tempdir in session.config.workflow_cleanup_dirs:
-            shutil.rmtree(str(tempdir))
 
 
 class YamlFile(pytest.File):

--- a/src/pytest_workflow/plugin.py
+++ b/src/pytest_workflow/plugin.py
@@ -149,20 +149,18 @@ def pytest_collection_modifyitems(config: PytestConfig,
     for item in items:
         marker = item.get_closest_marker(name="workflow")  # type: Optional[MarkDecorator] # noqa: E501
         if marker is not None:
-            try:
-                workflow_name = marker.kwargs['name']
-            except KeyError:
+            workflow_name = marker.kwargs.get('name')
+            if workflow_name is None:
                 # If name key is not defined use the first arg.
-                try:
+                if len(marker.args) >= 1:
                     workflow_name = marker.args[0]
                     # Make sure a marker with name is added anyway for the
                     # fixture lookup.
                     marker.kwargs['name'] = workflow_name
-                except IndexError:
+                else:
                     raise ValueError(
                         "A workflow name should be defined in the "
-                        "workflow marker of {0}".format(item.name)
-                        )
+                        "workflow marker of {0}".format(item.nodeid))
             if workflow_name not in config.executed_workflows:
                 skip_marker = pytest.mark.skip(
                     reason="'{0}' has not run.".format(workflow_name))

--- a/src/pytest_workflow/plugin.py
+++ b/src/pytest_workflow/plugin.py
@@ -21,8 +21,9 @@ import warnings
 from pathlib import Path
 from typing import List, Optional  # noqa: F401 needed for typing.
 
-from _pytest import config as pytest_config
-from _pytest.config import argparsing as pytest_argparsing
+from _pytest.config import Config as PytestConfig
+from _pytest.config.argparsing import Parser as PytestParser
+from _pytest.mark import MarkDecorator
 import pytest
 
 import yaml
@@ -34,7 +35,7 @@ from .schema import WorkflowTest, workflow_tests_from_schema
 from .workflow import Workflow, WorkflowQueue
 
 
-def pytest_addoption(parser: pytest_argparsing.Parser):
+def pytest_addoption(parser: PytestParser):
     parser.addoption(
         "--keep-workflow-wd",
         action="store_true",
@@ -84,7 +85,7 @@ def pytest_collect_file(path, parent):
     return None
 
 
-def pytest_configure(config: pytest_config.Config):
+def pytest_configure(config: PytestConfig):
     """This runs before tests start and adds values to the config."""
     # We need to add a workflow queue to some central variable. Instead of
     # using a global variable we add a value to the config.
@@ -132,14 +133,17 @@ def pytest_collection(session: pytest.Session):
 
 
 def pytest_collection_modify_items(session: pytest.Session,
-                                   config: pytest_config.Config,
+                                   config: PytestConfig,
                                    items: List[pytest.Item]):
     """This function modifies all items after test collection. This allows us
     to select tests that are marked to depend on a workflow and make the
     required modifications."""
+    for item in items:
+        marker = item.get_closest_marker(name="workflow")  # type: Optional[MarkDecorator] # noqa: E501
+        if marker is not None:
+            item.setup()
 
-
-def pytest_runtestloop(session):
+def pytest_runtestloop(session: pytest.Session):
     """This runs after collection, but before the tests."""
     session.config.workflow_queue.process(
         session.config.getoption("workflow_threads")

--- a/src/pytest_workflow/plugin.py
+++ b/src/pytest_workflow/plugin.py
@@ -208,7 +208,7 @@ def workflow_dir(request: SubRequest):
         try:
             workflow_name = marker.kwargs['name']
         except KeyError:
-            raise ValueError(
+            raise TypeError(
                 "A workflow name should be defined in the "
                 "workflow marker of {0}".format(request.node.nodeid))
         return workflow_temp_dir / Path(replace_whitespace(workflow_name))

--- a/src/pytest_workflow/plugin.py
+++ b/src/pytest_workflow/plugin.py
@@ -155,7 +155,7 @@ def pytest_collection_modifyitems(config: PytestConfig,
                 # If name key is not defined use the first arg.
                 if len(marker.args) >= 1:
                     workflow_name = marker.args[0]
-                    # Make sure a marker with name is added anyway for the
+                    # Make sure a name attribute is added anyway for the
                     # fixture lookup.
                     marker.kwargs['name'] = workflow_name
                 else:
@@ -283,7 +283,11 @@ class WorkflowTestsCollector(pytest.Collector):
         # Add the workflow to the workflow queue.
         self.config.workflow_queue.put(workflow)
 
-        # Add the tempdir to the removal queue.
+        # Add the tempdir to the removal queue. We do not use a teardown method
+        # because this will remove the tempdir right after all the tests from
+        # this node have finished. If custom tests are defined this should not
+        # happen. The removal queue is processed just before pytest finishes
+        # and all tests have run.
         self.config.workflow_cleanup_dirs.append(tempdir)
         return workflow
 

--- a/src/pytest_workflow/plugin.py
+++ b/src/pytest_workflow/plugin.py
@@ -19,8 +19,10 @@ import shutil
 import tempfile
 import warnings
 from pathlib import Path
-from typing import Optional  # noqa: F401 needed for typing.
+from typing import List, Optional  # noqa: F401 needed for typing.
 
+from _pytest import config as pytest_config
+from _pytest.config import argparsing as pytest_argparsing
 import pytest
 
 import yaml
@@ -32,7 +34,7 @@ from .schema import WorkflowTest, workflow_tests_from_schema
 from .workflow import Workflow, WorkflowQueue
 
 
-def pytest_addoption(parser):
+def pytest_addoption(parser: pytest_argparsing.Parser):
     parser.addoption(
         "--keep-workflow-wd",
         action="store_true",
@@ -82,7 +84,7 @@ def pytest_collect_file(path, parent):
     return None
 
 
-def pytest_configure(config):
+def pytest_configure(config: pytest_config.Config):
     """This runs before tests start and adds values to the config."""
     # We need to add a workflow queue to some central variable. Instead of
     # using a global variable we add a value to the config.
@@ -116,7 +118,7 @@ def pytest_configure(config):
     setattr(config, "workflow_dir", workflow_dir)
 
 
-def pytest_collection(session):
+def pytest_collection(session: pytest.Session):
     """This function is started at the beginning of collection"""
     # pylint: disable=unused-argument
     # needed for pytest
@@ -127,6 +129,14 @@ def pytest_collection(session):
     # Collecting ...
     # queue (etc.)
     print()
+
+
+def pytest_collection_modify_items(session: pytest.Session,
+                                   config: pytest_config.Config,
+                                   items: List[pytest.Item]):
+    """This function modifies all items after test collection. This allows us
+    to select tests that are marked to depend on a workflow and make the
+    required modifications."""
 
 
 def pytest_runtestloop(session):

--- a/src/pytest_workflow/plugin.py
+++ b/src/pytest_workflow/plugin.py
@@ -132,7 +132,7 @@ def pytest_collection(session: pytest.Session):
     print()
 
 
-def pytest_collection_modify_items(session: pytest.Session,
+def pytest_collection_modifyitems(session: pytest.Session,
                                    config: PytestConfig,
                                    items: List[pytest.Item]):
     """This function modifies all items after test collection. This allows us

--- a/src/pytest_workflow/plugin.py
+++ b/src/pytest_workflow/plugin.py
@@ -98,11 +98,11 @@ def pytest_configure(config: PytestConfig):
     setattr(config, "workflow_queue", workflow_queue)
 
     # Save which workflows are run and which are not.
-    executed_workflows = []
+    executed_workflows = []  # type: List[str]
     setattr(config, "executed_workflows", executed_workflows)
 
     # Save workflow for cleanup in this var.
-    workflow_cleanup_dirs = []
+    workflow_cleanup_dirs = []  # type: List[str]
     setattr(config, "workflow_cleanup_dirs", workflow_cleanup_dirs)
 
     # When multiple workflows are started they should all be set in the same

--- a/src/pytest_workflow/workflow.py
+++ b/src/pytest_workflow/workflow.py
@@ -139,7 +139,11 @@ class Workflow(object):
     @property
     def exit_code(self) -> int:
         self.wait()
-        return self._popen.returncode
+        if self._popen is not None:
+            return self._popen.returncode
+        else:
+            raise ValueError("No exit code after waiting. Please contact the "
+                             "developers and report this issue.")
 
 
 class WorkflowQueue(queue.Queue):

--- a/tests/test_workflow_dependent_tests.py
+++ b/tests/test_workflow_dependent_tests.py
@@ -52,11 +52,14 @@ import pytest
 @pytest.mark.workflow(name="simple echo")
 def test_fixture_impl(workflow_dir):
     assert workflow_dir.name == "simple_echo"
+    assert workflow_dir.exists()
 """)
 
 
 def test_workflow_dir_arg(testdir):
-    testdir.makefile(".yml", test_simple=SIMPLE_ECHO)
+    # Call the test, `test_asimple` because tests are run alphabetically.
+    # This will detect if the workflow dir has been removed.
+    testdir.makefile(".yml", test_asimple=SIMPLE_ECHO)
     testdir.makefile(".py", test_fixture=TEST_FIXTURE)
     result = testdir.runpytest()
     result.assert_outcomes(passed=5, failed=0, error=0, skipped=0)
@@ -65,7 +68,7 @@ def test_workflow_dir_arg(testdir):
 def test_worfklow_dir_arg_skipped(testdir):
     """Run this test to check if this does not run into fixture request
     errors"""
-    testdir.makefile(".yml", test_simple=SIMPLE_ECHO)
+    testdir.makefile(".yml", test_asimple=SIMPLE_ECHO)
     testdir.makefile(".py", test_fixture=TEST_FIXTURE)
     result = testdir.runpytest("-v", "-r", "s", "--tag", "flaksdlkad")
     result.assert_outcomes(skipped=1)
@@ -83,7 +86,7 @@ def test_fixture_impl(workflow_dir):
 def test_worfklow_not_exist_dir_arg(testdir):
     """Run this test to check if this does not run into fixture request
     errors"""
-    testdir.makefile(".yml", test_simple=SIMPLE_ECHO)
+    testdir.makefile(".yml", test_asimple=SIMPLE_ECHO)
     testdir.makefile(".py", test_fixture=TEST_FIXTURE_WORKFLOW_NOT_EXIST)
     result = testdir.runpytest("-v", "-r", "s")
     result.assert_outcomes(skipped=1, passed=4)
@@ -101,7 +104,7 @@ def test_fixture_impl(workflow_dir):
 def test_fixture_unmarked_test(testdir):
     """Run this test to check if this does not run into fixture request
     errors"""
-    testdir.makefile(".yml", test_simple=SIMPLE_ECHO)
+    testdir.makefile(".yml", test_asimple=SIMPLE_ECHO)
     testdir.makefile(".py", test_fixture=TEST_FIXTURE_UNMARKED_TEST)
     result = testdir.runpytest("-v", "-r", "s")
     result.assert_outcomes(error=1, passed=4)
@@ -134,7 +137,7 @@ def test_fixture_usable_for_file_tests(testdir):
         assert int(number_file_content) % 3 == 0
     """)
 
-    testdir.makefile(".yml", test_workflow=test_workflow)
+    testdir.makefile(".yml", test_aworkflow=test_workflow)
     testdir.makefile(".py", test_div=test_div_by_three)
     result = testdir.runpytest("-v")
     result.assert_outcomes(passed=4, failed=0, skipped=0, error=0)

--- a/tests/test_workflow_dependent_tests.py
+++ b/tests/test_workflow_dependent_tests.py
@@ -123,6 +123,26 @@ def test_fixture_unmarked_test(testdir):
             "the workflow mark.") in result.stdout.str()
 
 
+TEST_MARK_WRONG_KEY = textwrap.dedent("""\
+import pytest
+
+@pytest.mark.workflow(naem="simple echo")
+def test_fixture_impl(workflow_dir):
+    assert workflow_dir.name == "simple_echo"
+    assert workflow_dir.exists()
+""")
+
+
+def test_mark_wrong_key(testdir):
+    """Run this test to check if this does not run into fixture request
+    errors"""
+    testdir.makefile(".yml", test_asimple=SIMPLE_ECHO)
+    testdir.makefile(".py", test_fixture=TEST_MARK_WRONG_KEY)
+    result = testdir.runpytest("-v", "-r", "s")
+    assert ("A workflow name should be defined in the"
+            "workflow marker of ") in result.stdout.str()
+
+
 def test_fixture_usable_for_file_tests(testdir):
     test_workflow = textwrap.dedent("""\
     - name: number files

--- a/tests/test_workflow_dependent_tests.py
+++ b/tests/test_workflow_dependent_tests.py
@@ -150,8 +150,9 @@ def test_mark_wrong_key(testdir):
     testdir.makefile(".yml", test_asimple=SIMPLE_ECHO)
     testdir.makefile(".py", test_fixture=TEST_MARK_WRONG_KEY)
     result = testdir.runpytest("-v", "-r", "s")
-    assert ("A workflow name should be defined in the"
+    assert ("A workflow name should be defined in the "
             "workflow marker of ") in result.stdout.str()
+    result.assert_outcomes(run=4, error=1)
 
 
 def test_fixture_usable_for_file_tests(testdir):

--- a/tests/test_workflow_dependent_tests.py
+++ b/tests/test_workflow_dependent_tests.py
@@ -153,7 +153,6 @@ def test_mark_wrong_key(testdir):
     result = testdir.runpytest("-v", "-r", "s")
     assert ("A workflow name should be defined in the "
             "workflow marker of ") in result.stdout.str()
-    result.assert_outcomes(run=4, error=1)
 
 
 def test_fixture_usable_for_file_tests(testdir):

--- a/tests/test_workflow_dependent_tests.py
+++ b/tests/test_workflow_dependent_tests.py
@@ -58,4 +58,4 @@ def test_workflow_dir_arg(testdir):
     testdir.makefile(".yml", test_simple=SIMPLE_ECHO)
     testdir.makefile(".py", test_fixture=TEST_FIXTURE)
     result = testdir.runpytest()
-    assert result.assert_outcomes(passed=5, failed=0, error=0, skipped=0)
+    result.assert_outcomes(passed=5, failed=0, error=0, skipped=0)

--- a/tests/test_workflow_dependent_tests.py
+++ b/tests/test_workflow_dependent_tests.py
@@ -88,7 +88,7 @@ def test_workflow_dir_arg(test, testdir):
 
 
 @pytest.mark.parametrize("test", [TEST_FIXTURE_KWARGS, TEST_FIXTURE_ARGS])
-def test_worfklow_dir_arg_skipped(test, testdir):
+def test_workflow_dir_arg_skipped(test, testdir):
     """Run this test to check if this does not run into fixture request
     errors"""
     testdir.makefile(".yml", test_asimple=SIMPLE_ECHO)
@@ -106,7 +106,7 @@ def test_fixture_impl(workflow_dir):
 """)
 
 
-def test_worfklow_not_exist_dir_arg(testdir):
+def test_workflow_not_exist_dir_arg(testdir):
     """Run this test to check if this does not run into fixture request
     errors"""
     testdir.makefile(".yml", test_asimple=SIMPLE_ECHO)

--- a/tests/test_workflow_dependent_tests.py
+++ b/tests/test_workflow_dependent_tests.py
@@ -23,10 +23,17 @@ from .test_success_messages import SIMPLE_ECHO
 TEST_HOOK = textwrap.dedent("""\
 import pytest
 
-
 @pytest.mark.workflow(name="simple echo")
 def test_hook_impl():
     assert True
+""")
+
+TEST_FIXTURE = textwrap.dedent("""\
+import pytest
+
+@pytest.mark.workflow(name="simple echo")
+def test_fixture_impl(workflow_dir):
+    assert workflow_dir.name == "simple_echo"
 """)
 
 
@@ -45,3 +52,10 @@ def test_skipped(testdir):
     result = testdir.runpytest("-v", "-r", "s", "--tag", "flaksdlkad")
     result.assert_outcomes(skipped=1)
     assert "'simple echo' has not run." in result.stdout.str()
+
+
+def test_workflow_dir_arg(testdir):
+    testdir.makefile(".yml", test_simple=SIMPLE_ECHO)
+    testdir.makefile(".py", test_fixture=TEST_FIXTURE)
+    result = testdir.runpytest()
+    assert result.assert_outcomes(passed=5, failed=0, error=0, skipped=0)

--- a/tests/test_workflow_dependent_tests.py
+++ b/tests/test_workflow_dependent_tests.py
@@ -25,14 +25,23 @@ import pytest
 
 
 @pytest.mark.workflow(name="simple echo")
-def test_hook_impl(workflow_dir):
-    print("This runs!")
-    assert workflow_dir
+def test_hook_impl():
+    assert True
 """)
 
 
-def test_hook_worked(testdir):
+def test_not_skipped(testdir):
     testdir.makefile(".yml", test_simple=SIMPLE_ECHO)
     testdir.makefile(".py", test_hook=TEST_HOOK)
     result = testdir.runpytest()
-    assert "This runs!" in result.stdout.str()
+    result.assert_outcomes(passed=5)
+
+
+def test_skipped(testdir):
+    testdir.makefile(".yml", test_simple=SIMPLE_ECHO)
+    testdir.makefile(".py", test_hook=TEST_HOOK)
+    # No workflow will run because the tag does not match
+    # ``-r s`` gives the reason why a test was skipped.
+    result = testdir.runpytest("-v", "-r", "s", "--tag", "flaksdlkad")
+    result.assert_outcomes(skipped=1)
+    assert "'simple echo' has not run." in result.stdout.str()

--- a/tests/test_workflow_dependent_tests.py
+++ b/tests/test_workflow_dependent_tests.py
@@ -28,14 +28,6 @@ def test_hook_impl():
     assert True
 """)
 
-TEST_FIXTURE = textwrap.dedent("""\
-import pytest
-
-@pytest.mark.workflow(name="simple echo")
-def test_fixture_impl(workflow_dir):
-    assert workflow_dir.name == "simple_echo"
-""")
-
 
 def test_not_skipped(testdir):
     testdir.makefile(".yml", test_simple=SIMPLE_ECHO)
@@ -54,8 +46,64 @@ def test_skipped(testdir):
     assert "'simple echo' has not run." in result.stdout.str()
 
 
+TEST_FIXTURE = textwrap.dedent("""\
+import pytest
+
+@pytest.mark.workflow(name="simple echo")
+def test_fixture_impl(workflow_dir):
+    assert workflow_dir.name == "simple_echo"
+""")
+
+
 def test_workflow_dir_arg(testdir):
     testdir.makefile(".yml", test_simple=SIMPLE_ECHO)
     testdir.makefile(".py", test_fixture=TEST_FIXTURE)
     result = testdir.runpytest()
     result.assert_outcomes(passed=5, failed=0, error=0, skipped=0)
+
+
+def test_worfklow_dir_arg_skipped(testdir):
+    """Run this test to check if this does not run into fixture request
+    errors"""
+    testdir.makefile(".yml", test_simple=SIMPLE_ECHO)
+    testdir.makefile(".py", test_fixture=TEST_FIXTURE)
+    result = testdir.runpytest("-v", "-r", "s", "--tag", "flaksdlkad")
+    result.assert_outcomes(skipped=1)
+
+
+TEST_FIXTURE_WORKFLOW_NOT_EXIST = textwrap.dedent("""\
+import pytest
+
+@pytest.mark.workflow(name="shoobiedoewap")
+def test_fixture_impl(workflow_dir):
+    assert workflow_dir.name == "simple_echo"
+""")
+
+
+def test_worfklow_not_exist_dir_arg(testdir):
+    """Run this test to check if this does not run into fixture request
+    errors"""
+    testdir.makefile(".yml", test_simple=SIMPLE_ECHO)
+    testdir.makefile(".py", test_fixture=TEST_FIXTURE_WORKFLOW_NOT_EXIST)
+    result = testdir.runpytest("-v", "-r", "s")
+    result.assert_outcomes(skipped=1, passed=4)
+    assert "'shoobiedoewap' has not run." in result.stdout.str()
+
+
+TEST_FIXTURE_UNMARKED_TEST = textwrap.dedent("""\
+import pytest
+
+def test_fixture_impl(workflow_dir):
+    assert workflow_dir.name == "simple_echo"
+""")
+
+
+def test_fixture_unmarked_test(testdir):
+    """Run this test to check if this does not run into fixture request
+    errors"""
+    testdir.makefile(".yml", test_simple=SIMPLE_ECHO)
+    testdir.makefile(".py", test_fixture=TEST_FIXTURE_UNMARKED_TEST)
+    result = testdir.runpytest("-v", "-r", "s")
+    result.assert_outcomes(error=1, passed=4)
+    assert ("workflow_dir can only be requested in tests marked with "
+            "the workflow mark.") in result.stdout.str()

--- a/tests/test_workflow_dependent_tests.py
+++ b/tests/test_workflow_dependent_tests.py
@@ -46,6 +46,7 @@ def test_not_skipped(test, testdir):
     result = testdir.runpytest()
     result.assert_outcomes(passed=5)
 
+
 @pytest.mark.parametrize("test", [TEST_HOOK_ARGS, TEST_HOOK_KWARGS])
 def test_skipped(test, testdir):
     testdir.makefile(".yml", test_simple=SIMPLE_ECHO)

--- a/tests/test_workflow_dependent_tests.py
+++ b/tests/test_workflow_dependent_tests.py
@@ -145,14 +145,16 @@ def test_fixture_impl(workflow_dir):
 """)
 
 
-def test_mark_wrong_key(testdir):
+def test_mark_wrong_key_with_fixture(testdir):
     """Run this test to check if this does not run into fixture request
     errors"""
     testdir.makefile(".yml", test_asimple=SIMPLE_ECHO)
     testdir.makefile(".py", test_fixture=TEST_MARK_WRONG_KEY)
     result = testdir.runpytest("-v", "-r", "s")
     assert ("A workflow name should be defined in the "
-            "workflow marker of ") in result.stdout.str()
+            "workflow marker of test_fixture.py::test_fixture_impl"
+            ) in result.stdout.str()
+    result.assert_outcomes(passed=4, error=1)
 
 
 def test_fixture_usable_for_file_tests(testdir):

--- a/tests/test_workflow_dependent_tests.py
+++ b/tests/test_workflow_dependent_tests.py
@@ -1,0 +1,38 @@
+# Copyright (C) 2018 Leiden University Medical Center
+# This file is part of pytest-workflow
+#
+# pytest-workflow is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# pytest-workflow is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with pytest-workflow.  If not, see <https://www.gnu.org/licenses/
+
+"""This tests the marker functionality that was added"""
+
+import textwrap
+
+from .test_success_messages import SIMPLE_ECHO
+
+TEST_HOOK = textwrap.dedent("""\
+import pytest
+
+
+@pytest.mark.workflow(name="simple echo")
+def test_hook_impl(workflow_dir):
+    print("This runs!")
+    assert workflow_dir
+""")
+
+
+def test_hook_worked(testdir):
+    testdir.makefile(".yml", test_simple=SIMPLE_ECHO)
+    testdir.makefile(".py", test_hook=TEST_HOOK)
+    result = testdir.runpytest()
+    assert "This runs!" in result.stdout.str()

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ commands =
     # Use csv format because it has cleanest output.
     bandit -s B101 -f csv -r src/ tests/
     pylint src/pytest_workflow/ tests/ setup.py
-    mypy src/pytest_workflow
+    mypy src/pytest_workflow tests/
 
 # Documentation should build on python version 3
 [testenv:py3-docs]

--- a/tox.ini
+++ b/tox.ini
@@ -22,7 +22,7 @@ commands =
     # Use csv format because it has cleanest output.
     bandit -s B101 -f csv -r src/ tests/
     pylint src/pytest_workflow/ tests/ setup.py
-    mypy -m src/pytest_workflow
+    mypy src/pytest_workflow
 
 # Documentation should build on python version 3
 [testenv:py3-docs]


### PR DESCRIPTION
Based on design in issue #56 .

+ Custom test syntax was added
+ Custom test syntax explained in the docs
+ Custom test syntax extensively tested
+ Apparently a `mypy` update caused our mypy linting to crash. It appears the way mypy was invoked was wrong all this time. This is now fixed.
+ Temporary workflow directories are not deleted until just before pytest exits. This allows all custom tests to run on workflow directories.
+ Apparently the conda/cromwell/tox/pip/pytest combination was not working correctly. Installing tox via cromwell fixed the issue, but it took me a while to debug this.

### Checklist
- [x] Pull request details were added to HISTORY.rst
