### PR TITLE
Add flag for disabling cleanup when tests fail.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,11 @@ Changelog
 .. NOTE: This document is user facing. Please word the changes in such a way
 .. that users understand how the changes affect the new version.
 
+version 1.2.0-dev
+---------------------------
++ Added a ``--keep-workflow-wd-on-fail`` or ``--kwdof`` flag. Setting this flag
+  will make sure temporary directories are only deleted when all tests succeed.
+
 version 1.1.2
 ---------------------------
 + Fixed a bug where the program would hang indefinitely after a user input

--- a/docs/running_pytest_workflow.rst
+++ b/docs/running_pytest_workflow.rst
@@ -8,11 +8,13 @@ Pytest will automatically gather files in the ``tests`` directory starting with
 
 The workflows are run automatically. Each workflow gets its own temporary
 directory to run. The ``stdout`` and ``stderr`` of the workflow command are
-also saved to this directory. The temporary directories are cleaned up after
-the tests are completed. If you wish to inspect the output of a failing
-workflow you can use the ``--kwd`` or ``--keep-workflow-wd`` flag to disable
-cleanup. This will also make sure the logs of the pipeline are not deleted. The
-``--keep-workflow-wd`` flag is highly recommended when debugging pipelines.
+also saved to this directory to ``log.out`` and ``log.err`` respectively.
+The temporary directories are cleaned up after the tests are completed.
+If you wish to inspect the output of a failing
+workflow you can use the ``--keep-workflow-wd`` or ``--kwd`` flag to disable
+cleanup. This will also make sure the logs of the pipeline are not deleted.
+If you only want to keep directories when one or more tests fail you can use
+the ``--keep-workflow-wd-on-fail`` or ``--kwdof`` flag.
 
 If you wish to change the temporary directory in which the workflows are run
 use ``--basetemp <dir>`` to change pytest's base temp directory.

--- a/docs/running_pytest_workflow.rst
+++ b/docs/running_pytest_workflow.rst
@@ -15,6 +15,8 @@ workflow you can use the ``--keep-workflow-wd`` or ``--kwd`` flag to disable
 cleanup. This will also make sure the logs of the pipeline are not deleted.
 If you only want to keep directories when one or more tests fail you can use
 the ``--keep-workflow-wd-on-fail`` or ``--kwdof`` flag.
+``--keep-workflow-wd-on-fail`` will keep all temporary directories, even from
+workflows that have succeeded.
 
 If you wish to change the temporary directory in which the workflows are run
 use ``--basetemp <dir>`` to change pytest's base temp directory.

--- a/src/pytest_workflow/plugin.py
+++ b/src/pytest_workflow/plugin.py
@@ -46,7 +46,7 @@ def pytest_addoption(parser: PytestParser):
              "stderr in the workflow directory",
         dest="keep_workflow_wd")
     parser.addoption(
-        "--kwdof", "--keep-worfklow-wd-on-fail",
+        "--kwdof", "--keep-workflow-wd-on-fail",
         action="store_true",
         help="Similar to --keep-workflow-wd, but only keeps the temporary "
              "directories if there are test failures. On success all "

--- a/src/pytest_workflow/plugin.py
+++ b/src/pytest_workflow/plugin.py
@@ -207,7 +207,7 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int):
         print("Removing temporary directories and logs. Use '--kwd' or "
               "'--keep-workflow-wd' to disable this behaviour.")
         cleanup()
-    return
+
 
 @pytest.fixture()
 def workflow_dir(request: SubRequest):

--- a/src/pytest_workflow/plugin.py
+++ b/src/pytest_workflow/plugin.py
@@ -46,6 +46,13 @@ def pytest_addoption(parser: PytestParser):
              "stderr in the workflow directory",
         dest="keep_workflow_wd")
     parser.addoption(
+        "--kwdof", "--keep-worfklow-wd-on-fail",
+        action="store_true",
+        help="Similar to --keep-workflow-wd, but only keeps the temporary "
+             "directories if there are test failures. On success all "
+             "directories are deleted.",
+        dest="keep_workflow_wd_on_fail")
+    parser.addoption(
         "--wt", "--workflow-threads",
         dest="workflow_threads",
         default=1,
@@ -178,10 +185,15 @@ def pytest_runtestloop(session: pytest.Session):
     )
 
 
-def pytest_sessionfinish(session: pytest.Session):
-    if not session.config.getoption("keep_workflow_wd"):
-        # The newline is needed otherwise everything looks ugly.
-        print("\nRemoving temporary directories and logs. Use '--kwd' or "
+def pytest_sessionfinish(session: pytest.Session, exitstatus: int):
+    keep_workflow_dirs = (
+            session.config.getoption("keep_workflow_wd") or (
+            session.config.getoption("keep_workflow_wd_on_fail")
+            and exitstatus != 0)
+    )
+
+    if not keep_workflow_dirs:
+        print("Removing temporary directories and logs. Use '--kwd' or "
               "'--keep-workflow-wd' to disable this behaviour.")
         for tempdir in session.config.workflow_cleanup_dirs:
             shutil.rmtree(str(tempdir))

--- a/tests/test_temp_directory.py
+++ b/tests/test_temp_directory.py
@@ -25,7 +25,7 @@ from .test_success_messages import SIMPLE_ECHO
 def test_directory_kept(testdir):
     testdir.makefile(".yml", test=SIMPLE_ECHO)
     result = testdir.runpytest("-v", "--keep-workflow-wd")
-    working_dir = re.search(r"with command 'echo moo' in '([\w\/_-]*)'",
+    working_dir = re.search(r"with command 'echo moo' in '([\w/_-]*)'",
                             result.stdout.str()).group(1)
     assert Path(working_dir).exists()
     assert Path(working_dir / Path("log.out")).exists()
@@ -35,7 +35,7 @@ def test_directory_kept(testdir):
 def test_directory_not_kept(testdir):
     testdir.makefile(".yml", test=SIMPLE_ECHO)
     result = testdir.runpytest("-v")
-    working_dir = re.search(r"with command 'echo moo' in '([\w\/_-]*)'",
+    working_dir = re.search(r"with command 'echo moo' in '([\w/_-]*)'",
                             result.stdout.str()).group(1)
     assert not Path(working_dir).exists()
     assert ("Removing temporary directories and logs. Use '--kwd' or "
@@ -87,31 +87,34 @@ def test_basetemp_will_be_created(testdir):
 
 SUCCESS_TEST = """\
 - name: success
-  command: exit 0
+  command: bash -c 'exit 0'
 """
 
 FAIL_TEST = """\
 - name: fail
-  command: fail
+  command: bash -c 'exit 1'
 """
 
 
 def test_directory_kept_on_fail(testdir):
-    testdir.makefile(".yml", test=SIMPLE_ECHO)
+    testdir.makefile(".yml", test=FAIL_TEST)
     result = testdir.runpytest("-v", "--keep-workflow-wd-on-fail")
-    working_dir = re.search(r"with command 'fail' in '([\w\/_-]*)'",
-                            result.stdout.str()).group(1)
+    working_dir = re.search(
+        r"with command 'bash -c 'exit 1'' in '([\w/_-]*)'",
+        result.stdout.str()).group(1)
     assert Path(working_dir).exists()
     assert Path(working_dir / Path("log.out")).exists()
     assert Path(working_dir / Path("log.err")).exists()
     assert ("One or more tests failed. Keeping temporary directories and "
             "logs." in result.stdout.str())
 
+
 def test_directory_not_kept_on_succes(testdir):
-    testdir.makefile(".yml", test=SIMPLE_ECHO)
+    testdir.makefile(".yml", test=SUCCESS_TEST)
     result = testdir.runpytest("-v", "--kwdof")
-    working_dir = re.search(r"with command 'success' in '([\w\/_-]*)'",
-                            result.stdout.str()).group(1)
+    working_dir = re.search(
+        r"with command 'bash -c 'exit 0'' in '([\w/_-]*)'",
+        result.stdout.str()).group(1)
     assert not Path(working_dir).exists()
     assert ("All tests succeeded. Removing temporary directories and logs." in
             result.stdout.str())


### PR DESCRIPTION
Unfortunately it is not possible to do this the elegant way: only keep directories for workflows that have failing tests. Pytest does not provide functionality for that. 
So the algorithm is quite simple. Most of the lines of code are tests and documentation.

Fixes #69 

### Checklist
- [x] Pull request details were added to HISTORY.rst
