### PR TITLE
Display an error message when --basetemp is a subdirectory of pytest's CWD

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -11,6 +11,10 @@ version 1.2.0-dev
 ---------------------------
 + Added a ``--keep-workflow-wd-on-fail`` or ``--kwdof`` flag. Setting this flag
   will make sure temporary directories are only deleted when all tests succeed.
++ Giving a ``--basetemp`` directory that is within pytest's current working
+  directory will now raise an exception to prevent infinit recursive directory
+  copying.
++ The cleanup message is only displayed when pytest-workflow is used.
 
 version 1.1.2
 ---------------------------

--- a/src/pytest_workflow/__init__.py
+++ b/src/pytest_workflow/__init__.py
@@ -15,6 +15,9 @@
 # along with pytest-workflow.  If not, see <https://www.gnu.org/licenses/
 
 import re
+import shutil
+from pathlib import Path
+from typing import List
 
 
 # This function was created to ensure the same conversion is used throughout
@@ -27,3 +30,8 @@ def replace_whitespace(string: str, replace_with: str = '_') -> str:
     :return: The string with whitespace converted.
     """
     return re.sub(r'\s+', replace_with, string)
+
+
+def rm_dirs(directories: List[Path]):
+    for directory in directories:
+        shutil.rmtree(str(directory))

--- a/src/pytest_workflow/plugin.py
+++ b/src/pytest_workflow/plugin.py
@@ -30,7 +30,7 @@ import pytest
 
 import yaml
 
-from . import replace_whitespace
+from . import replace_whitespace, rm_dirs
 from .content_tests import ContentTestCollector
 from .file_tests import FileTestCollector
 from .schema import WorkflowTest, workflow_tests_from_schema
@@ -195,10 +195,6 @@ def pytest_runtestloop(session: pytest.Session):
 
 
 def pytest_sessionfinish(session: pytest.Session, exitstatus: int):
-    def cleanup():
-        for tempdir in session.config.workflow_cleanup_dirs:
-            shutil.rmtree(str(tempdir))
-
     # No cleanup needed if we keep workflow directories
     # Or if there are no directories to cleanup. (I.e. pytest-workflow plugin
     # was not used.)
@@ -210,14 +206,14 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int):
         if exitstatus == 0:
             print("All tests succeeded. Removing temporary directories and "
                   "logs.")
-            cleanup()
+            rm_dirs(session.config.workflow_cleanup_dirs)
         else:
             print("One or more tests failed. Keeping temporary directories "
                   "and logs.")
     else:  # When no flags are set. Remove temporary directories and logs.
         print("Removing temporary directories and logs. Use '--kwd' or "
               "'--keep-workflow-wd' to disable this behaviour.")
-        cleanup()
+        rm_dirs(session.config.workflow_cleanup_dirs)
 
 
 @pytest.fixture()

--- a/src/pytest_workflow/plugin.py
+++ b/src/pytest_workflow/plugin.py
@@ -199,11 +199,14 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int):
         for tempdir in session.config.workflow_cleanup_dirs:
             shutil.rmtree(str(tempdir))
 
-    # No cleanup needed if we keep workflow directories.
-    if session.config.getoption("keep_workflow_wd"):
-        # no cleanup()
+    # No cleanup needed if we keep workflow directories
+    # Or if there are no directories to cleanup. (I.e. pytest-workflow plugin
+    # was not used.)
+    if (session.config.getoption("keep_workflow_wd") or
+            len(session.config.workflow_cleanup_dirs) == 0):
         pass
     elif session.config.getoption("keep_workflow_wd_on_fail"):
+        # Ony cleanup if there are cleanup_dirs.
         if exitstatus == 0:
             print("All tests succeeded. Removing temporary directories and "
                   "logs.")
@@ -211,7 +214,6 @@ def pytest_sessionfinish(session: pytest.Session, exitstatus: int):
         else:
             print("One or more tests failed. Keeping temporary directories "
                   "and logs.")
-            # no cleanup()
     else:  # When no flags are set. Remove temporary directories and logs.
         print("Removing temporary directories and logs. Use '--kwd' or "
               "'--keep-workflow-wd' to disable this behaviour.")

--- a/src/pytest_workflow/plugin.py
+++ b/src/pytest_workflow/plugin.py
@@ -133,6 +133,15 @@ def pytest_configure(config: PytestConfig):
     workflow_temp_dir = (
         Path(basetemp) if basetemp is not None
         else Path(tempfile.mkdtemp(prefix="pytest_workflow_")))
+
+    rootdir = Path(str(config.rootdir))
+    # Raise an error if the workflow temporary directory of the rootdir
+    # (pytest's CWD). This will lead to infinite looping and copying.
+    if str(workflow_temp_dir.absolute()).startswith(str(rootdir.absolute())):
+        raise ValueError("'{0}' is a subdirectory of '{1}'. Please select a "
+                         "--basetemp that is not in pytest's current working "
+                         "directory.".format(workflow_temp_dir, rootdir))
+
     setattr(config, "workflow_temp_dir", workflow_temp_dir)
 
 

--- a/tests/test_temp_directory.py
+++ b/tests/test_temp_directory.py
@@ -85,6 +85,17 @@ def test_basetemp_will_be_created(testdir):
     assert result.ret == 0
 
 
+def test_basetemp_can_not_be_in_rootdir(testdir):
+    testdir.makefile(".yml", test=SIMPLE_ECHO)
+    testdir_path = Path(str(testdir.tmpdir))
+    tempdir = testdir_path / Path("tmp")
+    result = testdir.runpytest("-v", "--basetemp", str(tempdir))
+    message = "'{tempdir}' is a subdirectory of '{rootdir}'".format(
+        tempdir=str(tempdir),
+        rootdir=str(testdir_path))
+    assert message in result.stderr.str()
+
+
 SUCCESS_TEST = """\
 - name: success
   command: bash -c 'exit 0'


### PR DESCRIPTION
Also fixes that a cleanup message is printed while pytest-workflow was not used.
### Checklist
- [x] Pull request details were added to HISTORY.rst
