### PR TITLE
Add workflow marker to the config

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -9,6 +9,9 @@ Changelog
 
 version 1.3.0-dev
 ---------------------------
++ Since pytest 4.5.0 unknown markers give a warning. ``@pytest.mark.workflow``
+  markers are now added to the configuration. Information on usage shows up
+  with ``pytest --mark``.
 + Updated documentation to reflect the move to conda-forge as requested on
   `this github issue
   <https://github.com/bioconda/bioconda-recipes/issues/13964>`_.

--- a/src/pytest_workflow/plugin.py
+++ b/src/pytest_workflow/plugin.py
@@ -96,6 +96,14 @@ def pytest_collect_file(path, parent):
 
 def pytest_configure(config: PytestConfig):
     """This runs before tests start and adds values to the config."""
+
+    #  Add marker to the config to prevent issues caused by:
+    #  https://github.com/pytest-dev/pytest/issues/4826
+    # Errors are now emitted when unknown marks are included
+    config.addinivalue_line(
+       "markers", "workflow(name): mark test to run only with the given "
+                  "workflow name. Also accepts a list of names."
+    )
     # We need to add a workflow queue to some central variable. Instead of
     # using a global variable we add a value to the config.
     # Using setattr is not the nicest way of doing things, but having something

--- a/src/pytest_workflow/plugin.py
+++ b/src/pytest_workflow/plugin.py
@@ -102,7 +102,8 @@ def pytest_configure(config: PytestConfig):
     # Errors are now emitted when unknown marks are included
     config.addinivalue_line(
        "markers", "workflow(name): mark test to run only with the given "
-                  "workflow name. Also accepts a list of names."
+                  "workflow name. Also provides access to the workflow_dir "
+                  "fixture."
     )
     # We need to add a workflow queue to some central variable. Instead of
     # using a global variable we add a value to the config.

--- a/src/pytest_workflow/plugin.py
+++ b/src/pytest_workflow/plugin.py
@@ -101,9 +101,10 @@ def pytest_configure(config: PytestConfig):
     #  https://github.com/pytest-dev/pytest/issues/4826
     # Errors are now emitted when unknown marks are included
     config.addinivalue_line(
-       "markers", "workflow(name): mark test to run only with the given "
-                  "workflow name. Also provides access to the workflow_dir "
-                  "fixture."
+        "markers",
+        "workflow(name): mark test to run only with the given "
+        "workflow name. Also provides access to the workflow_dir "
+        "fixture."
     )
     # We need to add a workflow queue to some central variable. Instead of
     # using a global variable we add a value to the config.

--- a/tests/test_workflow_dependent_tests.py
+++ b/tests/test_workflow_dependent_tests.py
@@ -97,6 +97,14 @@ def test_workflow_dir_arg_skipped(test, testdir):
     result.assert_outcomes(skipped=1)
 
 
+@pytest.mark.parametrize("test", [TEST_FIXTURE_ARGS])
+def test_mark_not_unknown(test, testdir):
+    testdir.makefile(".yml", test_asimple=SIMPLE_ECHO)
+    testdir.makefile(".py", test_fixture=test)
+    result = testdir.runpytest("-v")
+    assert "PytestUnknownMarkWarning" not in result.stdout.str()
+
+
 TEST_FIXTURE_WORKFLOW_NOT_EXIST = textwrap.dedent("""\
 import pytest
 


### PR DESCRIPTION
Prevents a pytest warning from occurring.
### Checklist
- [x] Pull request details were added to HISTORY.rst
