### PR TITLE
add manifest with license

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -11,6 +11,8 @@ version 1.3.0-dev
 ---------------------------
 + Make sure pytest-workflow crashes when multiple workflows have the same name,
   even when they are in different files.
++ Added MANIFEST.in to include license in source distributions on PyPI for
+  future versions
 
 version 1.2.1
 ---------------------------

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE


### PR DESCRIPTION
This should solve #83. When creating a new source distribution with ``python setup.py sdist``, the LICENSE will now be included in the archive. Wheels were fine from the outset.  

### Checklist
- [x] Pull request details were added to HISTORY.rst
