### PR TITLE
Refactor pytest-workflow using python 3.6 tools.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -11,10 +11,18 @@ version 1.3-dev
 ---------------------------
 Python 3.6 and pytest 5.4.0.0 are now minimum requirements for pytest-workflow.
 This was necessary for fixing the deprecation warning issue and the issue with
-the subdirectory evaluation.
+the subdirectory evaluation. This also gave the opportunity to simplify the
+source code using new python 3.6 syntax.
 
 Changes
 +++++++++++++++++++++++++++
++ Refactored the code base. Python 3.6's f-strings and type annotation were
+  used consistently throughout the project. Some code was rewritten to be more
+  concise and readable.
++ Improved speed for searching string content in files. This was achieved by
+  removing intermediate functions and simplifying the search function.
++ Improved speed for calculating md5sums by increasing the read buffer size
+  from 8k to 64k.
 + Solve issue where pytest would display a lot of deprecation warnings when
   running pytest-workflow. (`Issue #98
   <https://github.com/LUMC/pytest-workflow/issues/98>`_)

--- a/src/pytest_workflow/content_tests.py
+++ b/src/pytest_workflow/content_tests.py
@@ -179,14 +179,14 @@ class ContentTestItem(pytest.Item):
 
     def repr_failure(self, excinfo):
         if self.parent.file_not_found:
-            containing = "containing" if self.should_contain \
-                             else "not containing",
+            containing = ("containing" if self.should_contain else
+                          "not containing")
             return (
                 f"'{self.content_name}' does not exist and cannot be searched "
                 f"for {containing} '{self.string}'."
             )
         else:
-            found = "not found" if self.should_contain else "found",
+            found = "not found" if self.should_contain else "found"
             should = "should" if self.should_contain else "should not"
             return (
                 f"'{self.string}' was {found} in {self.content_name} "

--- a/src/pytest_workflow/content_tests.py
+++ b/src/pytest_workflow/content_tests.py
@@ -177,7 +177,7 @@ class ContentTestItem(pytest.Item):
         assert ((self.string in self.parent.found_strings) ==
                 self.should_contain)
 
-    def repr_failure(self, excinfo):
+    def repr_failure(self, excinfo, style=None):
         if self.parent.file_not_found:
             containing = ("containing" if self.should_contain else
                           "not containing")

--- a/src/pytest_workflow/content_tests.py
+++ b/src/pytest_workflow/content_tests.py
@@ -46,34 +46,20 @@ def check_content(strings: List[str],
 
     # Create two sets. By default all strings are not found.
     strings_to_check = set(strings)
-    found_strings = set()  # type: Set[str]
+    found_strings: Set[str] = set()
 
     for line in text_lines:
         # Break the loop if all strings are found
-        # First do length check for speed as this runs every loop.
-        if len(found_strings) == len(strings_to_check):
-            # Then true check
-            if found_strings == strings_to_check:
-                break
-            else:
-                raise ValueError(
-                    "The number of strings found is equal to the "
-                    "number of strings to be checked. But the"
-                    " sets are not equal. Please contact the "
-                    "developers to fix this issue.")
+        # Python implements fast set equality checking by checking length first
+        if found_strings == strings_to_check:
+            break
 
         for string in strings_to_check:
             if string not in found_strings and string in line:
                 found_strings.add(string)
-
-    if not found_strings.issubset(strings_to_check):
-        raise ValueError(
-            "Strings where found that were not searched for. Please contact"
-            " the developers to fix this issue. \n" +
-            "Searched for strings: {0}\n".format(strings_to_check) +
-            "Found strings: {0}\n".format(found_strings)
-        )
-
+        # Remove found strings for faster searching. This should be done
+        # outside of the loop above.
+        strings_to_check -= found_strings
     return found_strings
 
 

--- a/src/pytest_workflow/content_tests.py
+++ b/src/pytest_workflow/content_tests.py
@@ -157,7 +157,7 @@ class ContentTestItem(pytest.Item):
         debugging if the test fails
         """
         contain = "contains" if should_contain else "does not contain"
-        name = "{0} '{1}'".format(contain, string)
+        name = f"{contain} '{string}'"
         super().__init__(name, parent=parent)
         self.should_contain = should_contain
         self.string = string
@@ -179,22 +179,16 @@ class ContentTestItem(pytest.Item):
 
     def repr_failure(self, excinfo):
         if self.parent.file_not_found:
+            containing = "containing" if self.should_contain \
+                             else "not containing",
             return (
-                "'{content}' does not exist and cannot be searched "
-                "for {containing} '{string}'."
-            ).format(
-                content=self.content_name,
-                containing="containing" if self.should_contain
-                else "not containing",
-                string=self.string)
-
+                f"'{self.content_name}' does not exist and cannot be searched "
+                f"for {containing} '{self.string}'."
+            )
         else:
+            found = "not found" if self.should_contain else "found",
+            should = "should" if self.should_contain else "should not"
             return (
-                "'{string}' was {found} in {content} "
-                "while it {should} be there."
-            ).format(
-                string=self.string,
-                found="not found" if self.should_contain else "found",
-                content=self.content_name,
-                should="should" if self.should_contain else "should not"
+                f"'{self.string}' was {found} in {self.content_name} "
+                f"while it {should} be there."
             )

--- a/src/pytest_workflow/content_tests.py
+++ b/src/pytest_workflow/content_tests.py
@@ -159,6 +159,7 @@ class ContentTestItem(pytest.Item):
         contain = "contains" if should_contain else "does not contain"
         name = f"{contain} '{string}'"
         super().__init__(name, parent=parent)
+        self.parent: ContentTestCollector = parent  # explicitly declare type
         self.should_contain = should_contain
         self.string = string
         self.content_name = content_name

--- a/src/pytest_workflow/content_tests.py
+++ b/src/pytest_workflow/content_tests.py
@@ -23,7 +23,7 @@ import functools
 import gzip
 import threading
 from pathlib import Path
-from typing import Iterable, List, Optional, Set
+from typing import Iterable, Optional, Set
 
 import pytest
 
@@ -31,7 +31,7 @@ from .schema import ContentTest
 from .workflow import Workflow
 
 
-def check_content(strings: List[str],
+def check_content(strings: Iterable[str],
                   text_lines: Iterable[str]) -> Set[str]:
     """
     Checks whether any of the strings is present in the text lines

--- a/src/pytest_workflow/file_tests.py
+++ b/src/pytest_workflow/file_tests.py
@@ -155,7 +155,6 @@ def file_md5sum(filepath: Path) -> str:
     :param filepath: a pathlib. Path to the file
     :return: a md5sum as hexadecimal string.
     """
-
     hasher = hashlib.md5()  # nosec: only used for file integrity
     with filepath.open('rb') as file_handler:  # Read the file in bytes
         # Hardcode the blocksize at 8192 bytes here.

--- a/src/pytest_workflow/file_tests.py
+++ b/src/pytest_workflow/file_tests.py
@@ -101,7 +101,7 @@ class FileExists(pytest.Item):
         self.workflow.wait()
         assert self.file.exists() == self.should_exist
 
-    def repr_failure(self, excinfo):
+    def repr_failure(self, excinfo, style=None):
         exist = "not exist" if self.should_exist else "exist"
         should = "should" if self.should_exist else "should not"
         # self.file gives the actual path that was tested (including /tmp

--- a/src/pytest_workflow/file_tests.py
+++ b/src/pytest_workflow/file_tests.py
@@ -53,13 +53,14 @@ class FileTestCollector(pytest.Collector):
         # certain conditions are met.
         tests = []
 
-        tests += [FileExists(parent=self,
-                             filepath=filepath,
-                             should_exist=self.filetest.should_exist,
-                             workflow=self.workflow)]
+        tests += [FileExists.from_parent(
+            parent=self,
+            filepath=filepath,
+            should_exist=self.filetest.should_exist,
+            workflow=self.workflow)]
 
         if self.filetest.contains or self.filetest.must_not_contain:
-            tests += [ContentTestCollector(
+            tests += [ContentTestCollector.from_parent(
                 name="content",
                 parent=self,
                 filepath=filepath,
@@ -68,7 +69,7 @@ class FileTestCollector(pytest.Collector):
                 workflow=self.workflow)]
 
         if self.filetest.md5sum:
-            tests += [FileMd5(
+            tests += [FileMd5.from_parent(
                 parent=self,
                 filepath=filepath,
                 md5sum=self.filetest.md5sum,

--- a/src/pytest_workflow/file_tests.py
+++ b/src/pytest_workflow/file_tests.py
@@ -102,16 +102,13 @@ class FileExists(pytest.Item):
         assert self.file.exists() == self.should_exist
 
     def repr_failure(self, excinfo):
-        message = "'{path}' does {exist} while it {should}".format(
-            # self.file gives the actual path that was tested (including /tmp
-            # bits). self.parent.filetest.path gives the path that the user
-            # gave in the test yaml. self.file is probably more useful when
-            # debugging.
-            path=str(self.file),
-            exist="not exist" if self.should_exist else "exist",
-            should="should" if self.should_exist else "should not"
-        )
-        return message
+        exist = "not exist" if self.should_exist else "exist"
+        should = "should" if self.should_exist else "should not"
+        # self.file gives the actual path that was tested (including /tmp
+        # bits). self.parent.filetest.path gives the path that the user
+        # gave in the test yaml. self.file is probably more useful when
+        # debugging.
+        return f"'{str(self.file)}' does {exist} while it {should}"
 
 
 class FileMd5(pytest.Item):
@@ -138,15 +135,10 @@ class FileMd5(pytest.Item):
         assert self.observed_md5sum == self.expected_md5sum
 
     def repr_failure(self, excinfo):
-        message = (
-            "Observed md5sum '{observed}' not equal to expected md5sum "
-            "'{expected}' for file '{path}'"
-        ).format(
-            observed=self.observed_md5sum,
-            expected=self.expected_md5sum,
-            path=str(self.filepath)
+        return (
+            f"Observed md5sum '{self.observed_md5sum}' not equal to expected "
+            f"md5sum '{self.expected_md5sum}' for file '{self.filepath}'"
         )
-        return message
 
 
 def file_md5sum(filepath: Path) -> str:

--- a/src/pytest_workflow/file_tests.py
+++ b/src/pytest_workflow/file_tests.py
@@ -134,7 +134,7 @@ class FileMd5(pytest.Item):
         self.observed_md5sum = file_md5sum(self.filepath)
         assert self.observed_md5sum == self.expected_md5sum
 
-    def repr_failure(self, excinfo):
+    def repr_failure(self, excinfo, style=None):
         return (
             f"Observed md5sum '{self.observed_md5sum}' not equal to expected "
             f"md5sum '{self.expected_md5sum}' for file '{self.filepath}'"

--- a/src/pytest_workflow/file_tests.py
+++ b/src/pytest_workflow/file_tests.py
@@ -141,10 +141,12 @@ class FileMd5(pytest.Item):
         )
 
 
-def file_md5sum(filepath: Path) -> str:
+# block_size 64k with python is a few percent faster than linux native md5sum.
+def file_md5sum(filepath: Path, block_size=64 * 1024) -> str:
     """
     Generates a md5sum for a file. Reads file in blocks to save memory.
     :param filepath: a pathlib. Path to the file
+    :param block_size: Block size in bytes
     :return: a md5sum as hexadecimal string.
     """
     hasher = hashlib.md5()  # nosec: only used for file integrity
@@ -152,6 +154,6 @@ def file_md5sum(filepath: Path) -> str:
         # Hardcode the blocksize at 8192 bytes here.
         # This can be changed or made variable when the requirements compel us
         # to do so.
-        for block in iter(lambda: file_handler.read(8192), b''):
+        for block in iter(lambda: file_handler.read(block_size), b''):
             hasher.update(block)
     return hasher.hexdigest()

--- a/src/pytest_workflow/file_tests.py
+++ b/src/pytest_workflow/file_tests.py
@@ -151,9 +151,6 @@ def file_md5sum(filepath: Path, block_size=64 * 1024) -> str:
     """
     hasher = hashlib.md5()  # nosec: only used for file integrity
     with filepath.open('rb') as file_handler:  # Read the file in bytes
-        # Hardcode the blocksize at 8192 bytes here.
-        # This can be changed or made variable when the requirements compel us
-        # to do so.
         for block in iter(lambda: file_handler.read(block_size), b''):
             hasher.update(block)
     return hasher.hexdigest()

--- a/src/pytest_workflow/plugin.py
+++ b/src/pytest_workflow/plugin.py
@@ -131,11 +131,11 @@ def pytest_configure(config: PytestConfig):
     setattr(config, "workflow_queue", workflow_queue)
 
     # Save which workflows are run and which are not.
-    executed_workflows = {}  # type: Dict[str, str]
+    executed_workflows: Dict[str, str] = {}
     setattr(config, "executed_workflows", executed_workflows)
 
     # Save workflow for cleanup in this var.
-    workflow_cleanup_dirs = []  # type: List[str]
+    workflow_cleanup_dirs: List[str] = []
     setattr(config, "workflow_cleanup_dirs", workflow_cleanup_dirs)
 
     # When multiple workflows are started they should all be set in the same
@@ -187,8 +187,8 @@ def pytest_collection_modifyitems(config: PytestConfig,
     """Here we skip all tests related to workflows that are not executed"""
 
     for item in items:
-        marker = item.get_closest_marker(
-            name="workflow")  # type: Optional[MarkDecorator] # noqa: E501
+        marker: Optional[MarkDecorator] = item.get_closest_marker(
+            name="workflow")
 
         if marker is None:
             continue
@@ -222,10 +222,11 @@ def pytest_collectstart(collector: pytest.Collector):
     """This runs before the collector runs its collect attribute"""
 
     if isinstance(collector, WorkflowTestsCollector):
-        name = collector.workflow_test.name  # type: str
+        name: str = collector.workflow_test.name
 
         # Executed workflows contains workflow name as key and nodeid as value.
-        executed_workflows = collector.config.executed_workflows  # type: Dict[str,str]  # noqa: E501
+        executed_workflows: Dict[str, str] = (
+            collector.config.executed_workflows)
 
         if name in executed_workflows.keys():
             raise ValueError(

--- a/src/pytest_workflow/plugin.py
+++ b/src/pytest_workflow/plugin.py
@@ -171,7 +171,7 @@ def pytest_configure(config: PytestConfig):
     setattr(config, "workflow_temp_dir", workflow_temp_dir)
 
 
-def pytest_collection(session: pytest.Session):
+def pytest_collection():
     """This function is started at the beginning of collection"""
     # We print an empty line here to make the report look slightly better.
     # Without it pytest will output "Collecting ... " and the workflow commands
@@ -423,7 +423,7 @@ class ExitCodeTest(pytest.Item):
         # workflow.exit_code waits for workflow to finish.
         assert self.workflow.exit_code == self.desired_exit_code
 
-    def repr_failure(self, excinfo):
+    def repr_failure(self, excinfo, style=None):
         message = (f"'{self.workflow.name}' exited with exit code " +
                    f"'{self.workflow.exit_code}' instead of "
                    f"'{self.desired_exit_code}'.")

--- a/src/pytest_workflow/plugin.py
+++ b/src/pytest_workflow/plugin.py
@@ -164,9 +164,9 @@ def pytest_configure(config: PytestConfig):
     # Raise an error if the workflow temporary directory of the rootdir
     # (pytest's CWD). This will lead to infinite looping and copying.
     if is_in_dir(workflow_temp_dir, rootdir):
-        raise ValueError("'{0}' is a subdirectory of '{1}'. Please select a "
-                         "--basetemp that is not in pytest's current working "
-                         "directory.".format(workflow_temp_dir, rootdir))
+        raise ValueError(f"'{workflow_temp_dir}' is a subdirectory of "
+                         f"'{rootdir}'. Please select a --basetemp that is "
+                         f"not in pytest's current working directory.")
 
     setattr(config, "workflow_temp_dir", workflow_temp_dir)
 
@@ -202,12 +202,12 @@ def pytest_collection_modifyitems(config: PytestConfig,
             # fixture lookup.
             marker.kwargs['name'] = workflow_name
         else:
-            raise TypeError("A workflow name should be defined in the "
-                            "workflow marker of {0}".format(item.nodeid))
+            raise TypeError(f"A workflow name should be defined in the "
+                            f"workflow marker of {item.nodeid}")
 
         if workflow_name not in config.executed_workflows.keys():
             skip_marker = pytest.mark.skip(
-                reason="'{0}' has not run.".format(workflow_name))
+                reason=f"'{workflow_name}' has not run.")
             item.add_marker(skip_marker)
 
 
@@ -229,12 +229,8 @@ def pytest_collectstart(collector: pytest.Collector):
 
         if name in executed_workflows.keys():
             raise ValueError(
-                "Workflow name '{this}' used more than once. Conflicting "
-                "tests: {this_test}, {existing_test}. ".format(
-                    this=name,
-                    this_test=collector.nodeid,
-                    existing_test=executed_workflows[name]
-                )
+                f"Workflow name '{name}' used more than once. Conflicting "
+                f"tests: {collector.nodeid}, {executed_workflows[name]}. "
             )
 
 
@@ -274,8 +270,8 @@ def workflow_dir(request: SubRequest):
             workflow_name = marker.kwargs['name']
         except KeyError:
             raise TypeError(
-                "A workflow name should be defined in the "
-                "workflow marker of {0}".format(request.node.nodeid))
+                f"A workflow name should be defined in the "
+                f"workflow marker of {request.node.nodeid}")
         return workflow_temp_dir / Path(replace_whitespace(workflow_name))
     else:
         raise ValueError("workflow_dir can only be requested in tests marked"
@@ -337,7 +333,7 @@ class WorkflowTestsCollector(pytest.Collector):
         # to work properly.
         if tempdir.exists():
             warnings.warn(
-                "'{0}' already exists. Deleting ...".format(tempdir))
+                f"'{tempdir}' already exists. Deleting ...")
             shutil.rmtree(str(tempdir))
 
         # Copy the project directory to the temporary directory using pytest's
@@ -428,9 +424,7 @@ class ExitCodeTest(pytest.Item):
         assert self.workflow.exit_code == self.desired_exit_code
 
     def repr_failure(self, excinfo):
-        message = ("'{workflow_name}' exited with exit code " +
-                   "'{exit_code}' instead of '{desired_exit_code}'."
-                   ).format(workflow_name=self.workflow.name,
-                            exit_code=self.workflow.exit_code,
-                            desired_exit_code=self.desired_exit_code)
+        message = (f"'{self.workflow.name}' exited with exit code " +
+                   f"'{self.workflow.exit_code}' instead of "
+                   f"'{self.desired_exit_code}'.")
         return message

--- a/src/pytest_workflow/plugin.py
+++ b/src/pytest_workflow/plugin.py
@@ -398,14 +398,14 @@ class WorkflowTestsCollector(pytest.Collector):
             filepath=workflow.stdout_file,
             content_test=self.workflow_test.stdout,
             workflow=workflow,
-            content_name="'{0}': stdout".format(self.workflow_test.name))]
+            content_name=f"'{self.workflow_test.name}': stdout")]
 
         tests += [ContentTestCollector.from_parent(
             name="stderr", parent=self,
             filepath=workflow.stderr_file,
             content_test=self.workflow_test.stderr,
             workflow=workflow,
-            content_name="'{0}': stderr".format(self.workflow_test.name))]
+            content_name=f"'{self.workflow_test.name}': stderr")]
 
         return tests
 
@@ -414,7 +414,7 @@ class ExitCodeTest(pytest.Item):
     def __init__(self, parent: pytest.Collector,
                  desired_exit_code: int,
                  workflow: Workflow):
-        name = "exit code should be {0}".format(desired_exit_code)
+        name = f"exit code should be {desired_exit_code}"
         super().__init__(name, parent=parent)
         self.workflow = workflow
         self.desired_exit_code = desired_exit_code

--- a/src/pytest_workflow/schema.py
+++ b/src/pytest_workflow/schema.py
@@ -55,8 +55,8 @@ def validate_schema(instance):
     test_names = [replace_whitespace(test['name'], ' ') for test in instance]
     if len(test_names) != len(set(test_names)):
         raise jsonschema.ValidationError(
-            "Some names were not unique when whitespace was removed. "
-            "Defined names: {0}".format(test_names))
+            f"Some names were not unique when whitespace was removed. "
+            f"Defined names: {test_names}")
 
     def test_contains_concordance(dictionary: dict, name: str):
         """
@@ -72,10 +72,9 @@ def validate_schema(instance):
             common_members = set(contains).intersection(set(must_not_contain))
             if common_members != set():
                 raise jsonschema.ValidationError(
-                    "contains and must_not_contain are not allowed to have the"
-                    " same members for the same object."
-                    " Object: {0}. Common members: {1}".format(name,
-                                                               common_members)
+                    f"contains and must_not_contain are not allowed to have "
+                    f"the same members for the same object. "
+                    f"Object: {name}. Common members: {common_members}"
                 )
 
     for test in instance:
@@ -93,9 +92,8 @@ def validate_schema(instance):
                 for check in ["md5sum", "contains", "must_not_contain"]:
                     if check in keys:
                         raise jsonschema.ValidationError(
-                            "Content checking not allowed " +
-                            "on non existing file: {0}. Key = {1}".format(
-                                test_file["path"], check))
+                            f"Content checking not allowed on non existing "
+                            f"file: {test_file['path']}. Key = {check}")
 
 
 # Schema classes below
@@ -104,6 +102,7 @@ def validate_schema(instance):
 # documenting members
 # TODO: Rewrite these into @Dataclass classes when python 3.7 becomes the
 # TODO: minimum required version.
+
 
 class ContentTest(object):
     """

--- a/src/pytest_workflow/schema.py
+++ b/src/pytest_workflow/schema.py
@@ -102,6 +102,8 @@ def validate_schema(instance):
 # These classes are created so that the test yaml does not have to be passed
 # around between test objects. But instead these objects which have self-
 # documenting members
+# TODO: Rewrite these into @Dataclass classes when python 3.7 becomes the
+# TODO: minimum required version.
 
 class ContentTest(object):
     """

--- a/src/pytest_workflow/schema.py
+++ b/src/pytest_workflow/schema.py
@@ -112,14 +112,8 @@ class ContentTest(object):
     """
     def __init__(self, contains: Optional[List[str]] = None,
                  must_not_contain: Optional[List[str]] = None):
-        if contains:
-            self.contains = contains
-        else:
-            self.contains = []
-        if must_not_contain:
-            self.must_not_contain = must_not_contain
-        else:
-            self.must_not_contain = []
+        self.contains: List[str] = contains or []
+        self.must_not_contain: List[str] = must_not_contain or []
 
     @classmethod
     def from_dict(cls, dictionary: dict):
@@ -131,7 +125,6 @@ class ContentTest(object):
 
 class FileTest(ContentTest):
     """A class that contains all the properties of a to be tested file."""
-
     def __init__(self, path: str, md5sum: Optional[str] = None,
                  should_exist: bool = DEFAULT_FILE_SHOULD_EXIST,
                  contains: Optional[List[str]] = None,
@@ -191,8 +184,8 @@ class WorkflowTest(object):
         self.exit_code = exit_code
         self.stdout = stdout
         self.stderr = stderr
-        self.files = files if files is not None else []
-        self.tags = tags if tags is not None else []
+        self.files = files or []
+        self.tags = tags or []
 
     @classmethod
     def from_schema(cls, schema: dict):

--- a/src/pytest_workflow/schema.py
+++ b/src/pytest_workflow/schema.py
@@ -38,26 +38,6 @@ def workflow_tests_from_schema(schema):
     return [WorkflowTest.from_schema(x) for x in schema]
 
 
-def test_contains_concordance(dictionary: dict, name: str):
-    """
-    Test whether contains and must not contain have the same members.
-    :param dictionary: part of the schema dictionary.
-    :param name: The name of the object the dictionary originates from.
-    This makes the error easier to comprehend for the user.
-    :return: An error if the test fails.
-    """
-    contains = dictionary.get("contains", [])
-    must_not_contain = dictionary.get("must_not_contain", [])
-    if len(contains) > 0 and len(must_not_contain) > 0:
-        common_members = set(contains).intersection(set(must_not_contain))
-        if common_members != set():
-            raise jsonschema.ValidationError(
-                f"contains and must_not_contain are not allowed to have "
-                f"the same members for the same object. "
-                f"Object: {name}. Common members: {common_members}"
-            )
-
-
 def validate_schema(instance):
     """
     Validates the pytest-workflow schema
@@ -77,6 +57,25 @@ def validate_schema(instance):
         raise jsonschema.ValidationError(
             f"Some names were not unique when whitespace was removed. "
             f"Defined names: {test_names}")
+
+    def test_contains_concordance(dictionary: dict, name: str):
+        """
+        Test whether contains and must not contain have the same members.
+        :param dictionary: part of the schema dictionary.
+        :param name: The name of the object the dictionary originates from.
+        This makes the error easier to comprehend for the user.
+        :return: An error if the test fails.
+        """
+        contains = dictionary.get("contains", [])
+        must_not_contain = dictionary.get("must_not_contain", [])
+        if len(contains) > 0 and len(must_not_contain) > 0:
+            common_members = set(contains).intersection(set(must_not_contain))
+            if common_members != set():
+                raise jsonschema.ValidationError(
+                    f"contains and must_not_contain are not allowed to have "
+                    f"the same members for the same object. "
+                    f"Object: {name}. Common members: {common_members}"
+                )
 
     for test in instance:
         test_contains_concordance(test.get('stdout', {}),

--- a/src/pytest_workflow/schema.py
+++ b/src/pytest_workflow/schema.py
@@ -116,13 +116,6 @@ class ContentTest(object):
         self.contains: List[str] = contains or []
         self.must_not_contain: List[str] = must_not_contain or []
 
-    @classmethod
-    def from_dict(cls, dictionary: dict):
-        return cls(
-            contains=dictionary.get("contains"),
-            must_not_contain=dictionary.get("must_not_contain")
-        )
-
 
 class FileTest(ContentTest):
     """A class that contains all the properties of a to be tested file."""
@@ -143,23 +136,6 @@ class FileTest(ContentTest):
         self.path = Path(path)
         self.md5sum = md5sum
         self.should_exist = should_exist
-
-    @classmethod
-    def from_dict(cls, dictionary: dict):
-        """
-        Creates a FileTest object from a dictionary
-        :param dictionary: dictionary containing at least a "path" key
-        :return: a FileTest object
-        """
-        return cls(
-            path=dictionary["path"],  # Compulsory value should fail
-            # when not present
-            md5sum=dictionary.get("md5sum"),
-            should_exist=dictionary.get("should_exist",
-                                        DEFAULT_FILE_SHOULD_EXIST),
-            contains=dictionary.get("contains"),
-            must_not_contain=dictionary.get("must_not_contain")
-        )
 
 
 class WorkflowTest(object):
@@ -192,14 +168,14 @@ class WorkflowTest(object):
     def from_schema(cls, schema: dict):
         """Generate a WorkflowTest object from schema objects"""
         test_file_dicts = schema.get("files", [])
-        test_files = [FileTest.from_dict(x) for x in test_file_dicts]
+        test_files = [FileTest(**d) for d in test_file_dicts]
 
         return cls(
             name=schema["name"],
             command=schema["command"],
             tags=schema.get("tags"),
             exit_code=schema.get("exit_code", DEFAULT_EXIT_CODE),
-            stdout=ContentTest.from_dict(schema.get("stdout", {})),
-            stderr=ContentTest.from_dict(schema.get("stderr", {})),
+            stdout=ContentTest(**schema.get("stdout", {})),
+            stderr=ContentTest(**schema.get("stderr", {})),
             files=test_files
         )

--- a/src/pytest_workflow/schema.py
+++ b/src/pytest_workflow/schema.py
@@ -38,6 +38,26 @@ def workflow_tests_from_schema(schema):
     return [WorkflowTest.from_schema(x) for x in schema]
 
 
+def test_contains_concordance(dictionary: dict, name: str):
+    """
+    Test whether contains and must not contain have the same members.
+    :param dictionary: part of the schema dictionary.
+    :param name: The name of the object the dictionary originates from.
+    This makes the error easier to comprehend for the user.
+    :return: An error if the test fails.
+    """
+    contains = dictionary.get("contains", [])
+    must_not_contain = dictionary.get("must_not_contain", [])
+    if len(contains) > 0 and len(must_not_contain) > 0:
+        common_members = set(contains).intersection(set(must_not_contain))
+        if common_members != set():
+            raise jsonschema.ValidationError(
+                f"contains and must_not_contain are not allowed to have "
+                f"the same members for the same object. "
+                f"Object: {name}. Common members: {common_members}"
+            )
+
+
 def validate_schema(instance):
     """
     Validates the pytest-workflow schema
@@ -57,25 +77,6 @@ def validate_schema(instance):
         raise jsonschema.ValidationError(
             f"Some names were not unique when whitespace was removed. "
             f"Defined names: {test_names}")
-
-    def test_contains_concordance(dictionary: dict, name: str):
-        """
-        Test whether contains and must not contain have the same members.
-        :param dictionary: part of the schema dictionary.
-        :param name: The name of the object the dictionary originates from.
-        This makes the error easier to comprehend for the user.
-        :return: An error if the test fails.
-        """
-        contains = dictionary.get("contains", [])
-        must_not_contain = dictionary.get("must_not_contain", [])
-        if len(contains) > 0 and len(must_not_contain) > 0:
-            common_members = set(contains).intersection(set(must_not_contain))
-            if common_members != set():
-                raise jsonschema.ValidationError(
-                    f"contains and must_not_contain are not allowed to have "
-                    f"the same members for the same object. "
-                    f"Object: {name}. Common members: {common_members}"
-                )
 
     for test in instance:
         test_contains_concordance(test.get('stdout', {}),

--- a/src/pytest_workflow/workflow.py
+++ b/src/pytest_workflow/workflow.py
@@ -119,8 +119,8 @@ class Workflow(object):
             if (timeout_secs is not None
                     and wait_time > timeout_secs):
                 raise TimeoutError(
-                    "Waiting on a workflow that has not started within the"
-                    " last {0} seconds".format(timeout_secs))
+                    f"Waiting on a workflow that has not started within the "
+                    f"last {timeout_secs} seconds")
             time.sleep(wait_interval_secs)
             wait_time += wait_interval_secs
 
@@ -210,15 +210,10 @@ class WorkflowQueue(queue.Queue):
                 break
             else:
                 print(
-                    "start '{name}' with command '{command}' in '{dir}'. "
-                    "stdout: '{stdout_file}'. "
-                    "stderr: '{stderr_file}'."
-                    .format(
-                        name=workflow.name,
-                        command=workflow.command,
-                        dir=workflow.cwd,
-                        stdout_file=workflow.stdout_file,
-                        stderr_file=workflow.stderr_file))
+                    f"start '{workflow.name}' with command "
+                    f"'{workflow.command}' in '{workflow.cwd}'. "
+                    f"stdout: '{workflow.stdout_file}'. "
+                    f"stderr: '{workflow.stderr_file}'.")
                 workflow.run()
                 # Collect the workflow errors.
                 self._process_errors.extend(workflow.errors)
@@ -226,4 +221,4 @@ class WorkflowQueue(queue.Queue):
                 # Some reporting
                 result = ("python error during starting"
                           if workflow.errors else "done")
-                print("'{0}' {1}.".format(workflow.name, result))
+                print(f"'{workflow.name}' {result}.")

--- a/src/pytest_workflow/workflow.py
+++ b/src/pytest_workflow/workflow.py
@@ -65,9 +65,9 @@ class Workflow(object):
                                              suffix=".err").name)
             if cwd is None
             else self.cwd / Path("log.err"))
-        self._popen = None  # type: Optional[subprocess.Popen]
+        self._popen: Optional[subprocess.Popen] = None
         self._started = False
-        self.errors = []  # type: List[Exception]
+        self.errors: List[Exception] = []
         self.start_lock = threading.Lock()
 
     def start(self):
@@ -205,7 +205,7 @@ class WorkflowQueue(queue.Queue):
             try:
                 # We know the type is Workflow, because this was enforced in
                 # the put method.
-                workflow = self.get_nowait()  # type: Workflow
+                workflow: Workflow = self.get_nowait()
             except queue.Empty:
                 break
             else:

--- a/tests/test_content_functions.py
+++ b/tests/test_content_functions.py
@@ -20,8 +20,7 @@ from pathlib import Path
 
 import pytest
 
-from pytest_workflow.content_tests import check_content, \
-    file_to_string_generator
+from pytest_workflow.content_tests import check_content
 
 LICENSE = Path(__file__).parent / Path("content_files") / Path("LICENSE")
 LICENSE_ZIPPED = LICENSE.parent / Path("LICENSE.gz")
@@ -43,19 +42,9 @@ SUCCEEDING_TESTS = [
                          SUCCEEDING_TESTS)
 def test_check_content_succeeding(contains_strings, does_not_contain_strings):
     all_strings = set(contains_strings).union(set(does_not_contain_strings))
-    found_strings = check_content(list(all_strings),
-                                  file_to_string_generator(LICENSE))
-    assert set(contains_strings) == found_strings
-    assert set(does_not_contain_strings) == all_strings - found_strings
-
-
-@pytest.mark.parametrize(["contains_strings", "does_not_contain_strings"],
-                         SUCCEEDING_TESTS)
-def test_check_content_succeeding_gzipped(contains_strings,
-                                          does_not_contain_strings):
-    all_strings = set(contains_strings).union(set(does_not_contain_strings))
-    found_strings = check_content(list(all_strings),
-                                  file_to_string_generator(LICENSE_ZIPPED))
+    with LICENSE.open("rt") as license_h:
+        found_strings = check_content(list(all_strings),
+                                      license_h)
     assert set(contains_strings) == found_strings
     assert set(does_not_contain_strings) == all_strings - found_strings
 
@@ -68,9 +57,3 @@ def test_multiple_finds_one_line():
     contains = ["dream", "day", "nation", "creed", "truths"]
     found_strings = check_content(contains, content)
     assert set(contains) == found_strings
-
-
-def test_file_to_string_iterator():
-    license_iterator = file_to_string_generator(LICENSE)
-    # This was checked using `wc -l`
-    assert len(list(license_iterator)) == 661

--- a/tests/test_content_functions.py
+++ b/tests/test_content_functions.py
@@ -22,7 +22,7 @@ import pytest
 
 from pytest_workflow.content_tests import check_content
 
-LICENSE = Path(__file__).parent / Path("content_files") / Path("LICENSE")
+LICENSE = Path(__file__).parent / Path("content_files", "LICENSE")
 LICENSE_ZIPPED = LICENSE.parent / Path("LICENSE.gz")
 
 # Yes we are checking the AGPLv3+. I am pretty sure some strings will not be

--- a/tests/test_fail_messages.py
+++ b/tests/test_fail_messages.py
@@ -22,7 +22,7 @@ from typing import List, Tuple  # noqa: F401  # Used in comments
 import pytest
 
 # message tests. Form: a tuple of a yaml file and expected messages.
-FAILURE_MESSAGE_TESTS: List[Tuple[str,str]] = [
+FAILURE_MESSAGE_TESTS: List[Tuple[str, str]] = [
     ("""\
     - name: fail_test
       command: grep

--- a/tests/test_fail_messages.py
+++ b/tests/test_fail_messages.py
@@ -22,7 +22,7 @@ from typing import List, Tuple  # noqa: F401  # Used in comments
 import pytest
 
 # message tests. Form: a tuple of a yaml file and expected messages.
-FAILURE_MESSAGE_TESTS = [
+FAILURE_MESSAGE_TESTS: List[Tuple[str,str]] = [
     ("""\
     - name: fail_test
       command: grep
@@ -124,7 +124,7 @@ FAILURE_MESSAGE_TESTS = [
     """,
      "moo.txt' does not exist and cannot be searched for "
      "not containing 'miaow'.")
-]  # type: List[Tuple[str,str]]
+]
 
 
 @pytest.mark.parametrize(["test", "message"], FAILURE_MESSAGE_TESTS)

--- a/tests/test_file_functions.py
+++ b/tests/test_file_functions.py
@@ -22,11 +22,11 @@ import pytest
 
 from pytest_workflow.file_tests import file_md5sum
 
-HASH_FILE_DIR = Path(Path(__file__).parent / Path("hash_files"))
+HASH_FILE_DIR = Path(__file__).parent / Path("hash_files")
 
-HASH_FILES_RELATIVE = os.listdir(HASH_FILE_DIR.absolute().__str__())
+HASH_FILES_RELATIVE = os.listdir(str(HASH_FILE_DIR.absolute()))
 
-HASH_FILES = [Path(HASH_FILE_DIR / Path(x)) for x in HASH_FILES_RELATIVE]
+HASH_FILES = [Path(HASH_FILE_DIR, x) for x in HASH_FILES_RELATIVE]
 
 
 @pytest.mark.parametrize("hash_file", HASH_FILES)

--- a/tests/test_miscellaneous_crashes.py
+++ b/tests/test_miscellaneous_crashes.py
@@ -25,8 +25,5 @@ def test_same_name_different_files(testdir):
     assert ("Workflow name 'simple echo' used more than once"
             in result.stdout.str())
     conflicting_message = (
-        "Conflicting tests: {0}, {1}.".format(
-            "test_b.yml::" + "simple echo",
-            "test_a.yml::" + "simple echo")
-    )
+        "Conflicting tests: test_b.yml::simple echo, test_a.yml::simple echo.")
     assert conflicting_message in result.stdout.str()

--- a/tests/test_multithreading.py
+++ b/tests/test_multithreading.py
@@ -25,7 +25,7 @@ import yaml
 # seconds on pytest-workflow 0.2 (without multithreading. So we should be a
 # a safe margin above that.
 SLEEP_TIME = 0.75
-SLEEP_COMMAND = "sleep {0}".format(SLEEP_TIME)
+SLEEP_COMMAND = f"sleep {SLEEP_TIME}"
 
 MULTHITHREADED_TEST = [
     dict(name="Doornroosje", command=SLEEP_COMMAND),

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -28,8 +28,8 @@ from pytest_workflow.schema import FileTest, WorkflowTest, validate_schema, \
 
 import yaml
 
-VALID_YAML_DIR = Path(__file__).parent / Path("yamls") / Path("valid")
-VALID_YAMLS = os.listdir(VALID_YAML_DIR.__str__())
+VALID_YAML_DIR = Path(__file__).parent / Path("yamls", "valid")
+VALID_YAMLS = os.listdir(VALID_YAML_DIR)
 
 
 @pytest.mark.parametrize("yaml_path", VALID_YAMLS)
@@ -147,7 +147,7 @@ def test_workflow_test_defaults():
     assert workflow_test.exit_code == 0
 
 
-def test_filtest_defaults():
+def test_filetest_defaults():
     file_test = FileTest(path="bla")
     assert file_test.contains == []
     assert file_test.must_not_contain == []

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -148,7 +148,7 @@ def test_workflow_test_defaults():
 
 
 def test_filtest_defaults():
-    file_test = FileTest.from_dict(dict(path="bla"))
+    file_test = FileTest(path="bla")
     assert file_test.contains == []
     assert file_test.must_not_contain == []
     assert file_test.md5sum is None

--- a/tests/test_temp_directory.py
+++ b/tests/test_temp_directory.py
@@ -47,11 +47,10 @@ def test_basetemp_correct(testdir):
     testdir.makefile(".yml", test=SIMPLE_ECHO)
     tempdir = tempfile.mkdtemp()
     result = testdir.runpytest("-v", "--basetemp", tempdir)
-    message = ("start 'simple echo' with command 'echo moo' in "
-               "'{tempdir}/simple_echo'. "
-               "stdout: '{tempdir}/simple_echo/log.out'. "
-               "stderr: '{tempdir}/simple_echo/log.err'."
-               ).format(tempdir=str(tempdir))
+    message = (f"start 'simple echo' with command 'echo moo' in "
+               f"'{tempdir}/simple_echo'. "
+               f"stdout: '{tempdir}/simple_echo/log.out'. "
+               f"stderr: '{tempdir}/simple_echo/log.err'.")
     assert message in result.stdout.str()
 
 
@@ -66,8 +65,7 @@ def test_basetemp_can_be_used_twice(testdir):
     result = testdir.runpytest("-v", "--keep-workflow-wd", "--basetemp",
                                tempdir)
     exit_code = result.ret
-    assert "'{0}/simple_echo' already exists. Deleting ...".format(
-        tempdir) in result.stdout.str()
+    assert "'{tempdir}/simple_echo' already exists. Deleting ..."
     assert exit_code == 0
 
 
@@ -90,9 +88,7 @@ def test_basetemp_can_not_be_in_rootdir(testdir):
     testdir_path = Path(str(testdir.tmpdir))
     tempdir = testdir_path / Path("tmp")
     result = testdir.runpytest("-v", "--basetemp", str(tempdir))
-    message = "'{tempdir}' is a subdirectory of '{rootdir}'".format(
-        tempdir=str(tempdir),
-        rootdir=str(testdir_path))
+    message = f"'{str(tempdir)}' is a subdirectory of '{str(testdir_path)}'"
     assert message in result.stderr.str()
 
 

--- a/tests/test_warnings.py
+++ b/tests/test_warnings.py
@@ -14,13 +14,13 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with pytest-workflow.  If not, see <https://www.gnu.org/licenses/
 
-from .test_success_messages import SIMPLE_ECHO
+from .test_success_messages import MOO_FILE
 
 
 # Add a test to make sure no deprecation, or other warnings occur due to
 # changes in upstream libraries.
 def test_no_warnings(testdir):
-    testdir.makefile(".yml", test_a=SIMPLE_ECHO)
+    testdir.makefile(".yml", test_a=MOO_FILE)
     result = testdir.runpytest()
     outcomes = result.parseoutcomes()
     assert outcomes.get('warnings', 0) == 0

--- a/tests/test_workflow_queue.py
+++ b/tests/test_workflow_queue.py
@@ -42,7 +42,7 @@ def test_workflow_queue_process_empty():
 
 
 def generate_sleep_workflows(number: int, sleep_time: float):
-    return [Workflow("sleep {0}".format(sleep_time)) for i in range(number)]
+    return [Workflow(f"sleep {sleep_time}") for _ in range(number)]
 
 
 QUEUE_TESTS = [


### PR DESCRIPTION
I have removed the file to string generator. A file handle is also a `Iterable[str]` type, so the content checking now iterates over the file handle itself. This is much faster as this file handle is implemented in C.

I also removed the length check of the sets before checking on equality. This was supposed to improve the speed, but in CPython this length check is already done before equality checking. CPython is of course much faster.

The same goes for removing the `found_strings` set from the `strings_to_check` set. If `found_strings` is empty, then this is detected very early in the algorithm and nothing is done to `strings_to_check`.

So it really helps to check the CPython implementation first before you make assumptions about speedy algorithms. 

### Checklist
- [x] Pull request details were added to HISTORY.rst
