### PR TITLE
Give more friendly errors on permission errors when trying to remove directories.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,13 @@ Changelog
 .. This document is user facing. Please word the changes in such a way
 .. that users understand how the changes affect the new version.
 
+version 1.5.0-dev
+---------------------------
++ Do not crash when directories can not be removed due to permission errors.
+  Instead display a message to notify the users which directories could not be
+  removed. These issues occurred sometimes when tests involving docker were
+  run.
+
 version 1.4.0
 ---------------------------
 + Usage of the ``name`` keyword argument in workflow marks is now deprecated.

--- a/src/pytest_workflow/plugin.py
+++ b/src/pytest_workflow/plugin.py
@@ -34,7 +34,7 @@ import yaml
 from .content_tests import ContentTestCollector
 from .file_tests import FileTestCollector
 from .schema import WorkflowTest, workflow_tests_from_schema
-from .util import is_in_dir, link_tree, replace_whitespace, rm_dirs
+from .util import is_in_dir, link_tree, replace_whitespace
 from .workflow import Workflow, WorkflowQueue
 
 
@@ -283,33 +283,42 @@ def pytest_collectstart(collector: pytest.Collector):
 
 
 def pytest_sessionfinish(session: pytest.Session, exitstatus: int):
-    # No cleanup needed if we keep workflow directories
-    # Or if there are no directories to cleanup. (I.e. pytest-workflow plugin
-    # was not used.)
-    removal: bool = False
-    if (session.config.getoption("keep_workflow_wd") or
-            len(session.config.workflow_cleanup_dirs) == 0):
-        pass
-    elif session.config.getoption("keep_workflow_wd_on_fail"):
-        # Ony cleanup if there are cleanup_dirs.
-        if exitstatus == 0:
-            print("All tests succeeded. Removing temporary directories and "
-                  "logs.")
-            removal = True
-        else:
-            print("One or more tests failed. Keeping temporary directories "
-                  "and logs.")
-    else:  # When no flags are set. Remove temporary directories and logs.
-        print("Removing temporary directories and logs. Use '--kwd' or "
-              "'--keep-workflow-wd' to disable this behaviour.")
-        removal = True
+    directories: List[Path] = session.config.workflow_cleanup_dirs
+    # No cleanup needed if there are no directories to cleanup. (I.e.
+    # pytest-workflow plugin was not used.)
+    if len(directories) == 0:
+        return
+
+    keep_workflow_wd: bool = session.config.getoption("keep_workflow_wd")
+    keep_workflow_wd_on_fail: bool = session.config.getoption(
+        "keep_workflow_wd_on_fail")
+    no_flags = not (keep_workflow_wd_on_fail and keep_workflow_wd)
+    success: bool = exitstatus == 0
+    removal: bool = not (keep_workflow_wd or (keep_workflow_wd_on_fail
+                                              and not success))
+
+    remove_msg = (f"{'Removing' if removal else 'Keeping'} "
+                  f"temporary directories and logs.")
+    # Only print success message if removal was dependent on success.
+    success_msg = (("All tests succeeded." if success else
+                   "One or more tests failed.")
+                   if keep_workflow_wd_on_fail else '')
+    # Only print message about flags if user did not use any flags.
+    no_flag_msg = ("Use '--kwd' or '--keep-workflow-wd' to disable this "
+                   "behaviour." if no_flags else "")
+    print(" ".join([success_msg, remove_msg, no_flag_msg]))
+
     if removal:
-        directories: List[Path] = session.config.workflow_cleanup_dirs
-        _, not_removed = rm_dirs(directories)
-        if not_removed:
+        unremovable_dirs: List[Path] = []
+        for directory in directories:
+            try:
+                shutil.rmtree(str(directory))
+            except PermissionError:
+                unremovable_dirs.append(directory)
+        if unremovable_dirs:
             print(f"Unable to remove the following directories due to "
                   f"permission errors: "
-                  f"{' ,'.join(str(path) for path in directories)}.")
+                  f"{' ,'.join(str(path) for path in unremovable_dirs)}.")
 
 
 class YamlFile(pytest.File):

--- a/src/pytest_workflow/util.py
+++ b/src/pytest_workflow/util.py
@@ -1,9 +1,7 @@
 import os
 import re
-import shutil
 import warnings
 from pathlib import Path
-from typing import List, Tuple
 
 
 # This function was created to ensure the same conversion is used throughout
@@ -16,23 +14,6 @@ def replace_whitespace(string: str, replace_with: str = '_') -> str:
     :return: The string with whitespace converted.
     """
     return re.sub(r'\s+', replace_with, string)
-
-
-def rm_dirs(directories: List[Path]) -> Tuple[List[Path], List[Path]]:
-    """
-    Remove directories using shutil. Catch permission errors.
-    :param directories: The directories to remove.
-    :return: A list of removed directories and unremovable directories.
-    """
-    removed_dirs: List[Path] = []
-    unremovable_dirs: List[Path] = []
-    for directory in directories:
-        try:
-            shutil.rmtree(str(directory))
-            removed_dirs.append(directory)
-        except PermissionError:
-            unremovable_dirs.append(directory)
-    return removed_dirs, unremovable_dirs
 
 
 def is_in_dir(child: Path, parent: Path, strict: bool = False) -> bool:

--- a/src/pytest_workflow/util.py
+++ b/src/pytest_workflow/util.py
@@ -3,7 +3,7 @@ import re
 import shutil
 import warnings
 from pathlib import Path
-from typing import List
+from typing import List, Tuple
 
 
 # This function was created to ensure the same conversion is used throughout
@@ -18,9 +18,21 @@ def replace_whitespace(string: str, replace_with: str = '_') -> str:
     return re.sub(r'\s+', replace_with, string)
 
 
-def rm_dirs(directories: List[Path]):
+def rm_dirs(directories: List[Path]) -> Tuple[List[Path], List[Path]]:
+    """
+    Remove directories using shutil. Catch permission errors.
+    :param directories: The directories to remove.
+    :return: A list of removed directories and unremovable directories.
+    """
+    removed_dirs: List[Path] = []
+    unremovable_dirs: List[Path] = []
     for directory in directories:
-        shutil.rmtree(str(directory))
+        try:
+            shutil.rmtree(str(directory))
+            removed_dirs.append(directory)
+        except PermissionError:
+            unremovable_dirs.append(directory)
+    return removed_dirs, unremovable_dirs
 
 
 def is_in_dir(child: Path, parent: Path, strict: bool = False) -> bool:


### PR DESCRIPTION
These issues cropped up when using Cromwell to run some tasks with docker, where the tool needed to run as a certain user (root for example). That would leave on the filesystem that can not be removed by pytest-workflow. 

This made pytest-workflow stop with a non-zero exit code, even though all tests succeeded. It also printed a stacktrace at the end of the results. This should now be alleviated. A message will be printed that states which directories could not be removed.

### Checklist
- [x] Pull request details were added to HISTORY.rst
