### PR TITLE
Make pytest-workflow git-aware

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -9,6 +9,13 @@ Changelog
 
 version 1.6.0-dev
 ---------------------------
++ Add a ``--git-aware`` or ``--ga`` option to only copy copy files listed by
+  git ls-files. This omits the ``.git`` folder and all git ignored files
+  which reduces the number of copy operations drastically.
+
+  Pytest-workflow will now emit a warning when copying of a git directory is
+  detected without the ``--git-aware`` option.
+
 + Add support and tests for Python 3.10
 
 version 1.5.0

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -10,8 +10,9 @@ Changelog
 version 1.6.0-dev
 ---------------------------
 + Add a ``--git-aware`` or ``--ga`` option to only copy copy files listed by
-  git ls-files. This omits the ``.git`` folder and all git ignored files
-  which reduces the number of copy operations drastically.
+  git ls-files. This omits the ``.git`` folder, all untracked files and
+  everything ignored by ``.gitignore``. This reduces the number of copy
+  operations drastically.
 
   Pytest-workflow will now emit a warning when copying of a git directory is
   detected without the ``--git-aware`` option.

--- a/docs/running_pytest_workflow.rst
+++ b/docs/running_pytest_workflow.rst
@@ -63,9 +63,9 @@ lot less disk space and be faster as well.
 .. note::
 
     When your workflow is version controlled in git please use the
-    ``--git-aware`` option. This will omit the ``.git`` directory and all
-    files ignored by git. This reduces the number of copy operations
-    significantly.
+    ``--git-aware`` option. This omits the ``.git`` folder, all untracked
+    files and everything ignored by ``.gitignore``. This reduces the number of
+    copy operations significantly.
 
 
 Running multiple workflows simultaneously

--- a/docs/running_pytest_workflow.rst
+++ b/docs/running_pytest_workflow.rst
@@ -55,11 +55,18 @@ The temporary directories created are copies of pytest's root directory, the
 directory from which it runs the tests. If you have lots of tests, and if you
 have a large repository, this may take a lot of disk space. To alleviate this
 you can use the ``--symlink`` flag which will create the same directory layout
-but instead symlinks the files instead of copying them. This is *slower* for
-lots of small files, and it carries with it the risk that the tests may alter
-files from your work directory. If there are a lot of large files and files are
-used read-only in tests, then it will use a lot less disk space and be faster
-as well.
+but instead symlinks the files instead of copying them. This carries with it
+the risk that the tests may alter files from your work directory. If there are
+a lot of large files and files are used read-only in tests, then it will use a
+lot less disk space and be faster as well.
+
+.. note::
+
+    When your workflow is version controlled in git please use the
+    ``--git-aware`` option. This will omit the ``.git`` directory and all
+    files ignored by git. This reduces the number of copy operations
+    significantly.
+
 
 Running multiple workflows simultaneously
 -----------------------------------------

--- a/src/pytest_workflow/plugin.py
+++ b/src/pytest_workflow/plugin.py
@@ -34,7 +34,7 @@ import yaml
 from .content_tests import ContentTestCollector
 from .file_tests import FileTestCollector
 from .schema import WorkflowTest, workflow_tests_from_schema
-from .util import is_in_dir, replace_whitespace, duplicate_tree
+from .util import duplicate_tree, is_in_dir, replace_whitespace
 from .workflow import Workflow, WorkflowQueue
 
 

--- a/src/pytest_workflow/plugin.py
+++ b/src/pytest_workflow/plugin.py
@@ -69,7 +69,8 @@ def pytest_addoption(parser: PytestParser):
     parser.addoption(
         "--ga", "--git-aware", action="store_true", dest="git_aware",
         help="Only copy files that are listed by the 'git ls-files' command. "
-             "This ignores the .git directory and any files in .gitignore. "
+             "This ignores the .git directory, any untracked files and any "
+             "files listed by .gitignore. "
              "Highly recommended when working in a git project.")
 
     # Why `--tag <tag>` and not simply use `pytest -m <tag>`?

--- a/src/pytest_workflow/plugin.py
+++ b/src/pytest_workflow/plugin.py
@@ -34,7 +34,7 @@ import yaml
 from .content_tests import ContentTestCollector
 from .file_tests import FileTestCollector
 from .schema import WorkflowTest, workflow_tests_from_schema
-from .util import is_in_dir, link_tree, replace_whitespace
+from .util import is_in_dir, replace_whitespace, duplicate_tree
 from .workflow import Workflow, WorkflowQueue
 
 
@@ -66,6 +66,11 @@ def pytest_addoption(parser: PytestParser):
              "symbolic links. This saves disk space, but should only be used "
              "for tests that do use these files read-only."
     )
+    parser.addoption(
+        "--ga", "--git-aware", action="store_true", dest="git_aware",
+        help="Only copy files that are listed by the 'git ls-files' command. "
+             "This ignores the .git directory and any files in .gitignore. "
+             "Highly recommended when working in a git project.")
 
     # Why `--tag <tag>` and not simply use `pytest -m <tag>`?
     # `-m` uses a "mark expression". So you have to type a piece of python
@@ -375,12 +380,22 @@ class WorkflowTestsCollector(pytest.Collector):
                 f"'{tempdir}' already exists. Deleting ...")
             shutil.rmtree(str(tempdir))
 
+        # Warn users of git that they should use the --git-aware option.
+        # The .git directory contains all files ever checked in, and all diffs
+        # in the entire history.
+        root_dir = Path(self.config.rootdir)
+        git_aware = self.config.getoption("git_aware")
+        git_dir = root_dir / ".git"
+        if git_dir.exists() and not git_aware:
+            warnings.warn(
+                f".git dir detected: {str(git_dir)}. pytest-workflow "
+                f"will copy the entire .git directory and all files ignored "
+                f"by git. It is recommended to use the --git-aware option.")
         # Copy the project directory to the temporary directory using pytest's
         # rootdir.
-        if self.config.getoption("symlink"):
-            link_tree(Path(str(self.config.rootdir)), tempdir)
-        else:
-            shutil.copytree(str(self.config.rootdir), str(tempdir))
+        duplicate_tree(root_dir, tempdir,
+                       symlink=self.config.getoption("symlink"),
+                       git_aware=git_aware)
 
         # Create a workflow and make sure it runs in the tempdir
         workflow = Workflow(command=self.workflow_test.command,

--- a/src/pytest_workflow/util.py
+++ b/src/pytest_workflow/util.py
@@ -96,13 +96,14 @@ def _duplicate_git_tree(src: Filepath, dest: Filepath
     # os.path.dirname when the path is in the current directory.
     dirs: Set[str] = {''}
     for path in git_ls_files(src):
-        # First check if parent is dir, so we can yield directories before
-        # files, to prevent creating files in non-existing directories.
+        # git ls-files does not list directories. So first check if parent is
+        # in dirs, so we can yield directories before files, to prevent
+        # creating files in non-existing directories.
         parent = os.path.dirname(path)
         if parent not in dirs:
-            src_path = os.path.join(src, parent)
-            dest_path = os.path.join(dest, parent)
-            yield src_path, dest_path, True
+            src_parent = os.path.join(src, parent)
+            dest_parent = os.path.join(dest, parent)
+            yield src_parent, dest_parent, True
 
         # Yield the actual file if the directory has already been yielded.
         src_path = os.path.join(src, path)

--- a/src/pytest_workflow/util.py
+++ b/src/pytest_workflow/util.py
@@ -58,7 +58,7 @@ def _run_command(*args):
     return result.stdout
 
 
-def git_get_root(path: Filepath) -> str:
+def git_root(path: Filepath) -> str:
     output = _run_command(
         "git", "-C", os.fspath(path), "rev-parse", "--show-toplevel")
     return output.strip()  # Remove trailing newline

--- a/src/pytest_workflow/util.py
+++ b/src/pytest_workflow/util.py
@@ -1,8 +1,8 @@
 import hashlib
 import os
 import re
+import subprocess  # nosec
 import sys
-import subprocess
 import warnings
 from pathlib import Path
 from typing import Iterator, List, Set, Tuple, Union
@@ -48,7 +48,7 @@ def is_in_dir(child: Path, parent: Path, strict: bool = False) -> bool:
 
 def _run_command(*args):
     """Run an external command and return the output"""
-    result = subprocess.run(args,
+    result = subprocess.run(args,  # nosec
                             stdout=subprocess.PIPE,
                             # Encoding to output as a string.
                             encoding=sys.getdefaultencoding(),
@@ -68,7 +68,8 @@ def git_ls_files(path: Filepath) -> List[str]:
     return output.strip("\n").split("\n")
 
 
-def _duplicate_tree(src: Filepath, dest: Filepath) -> Iterator[Tuple[str, str, bool]]:
+def _duplicate_tree(src: Filepath, dest: Filepath
+                    ) -> Iterator[Tuple[str, str, bool]]:
     """Traverses src and for each file or directory yields a path to it,
     its destination, and whether it is a directory."""
     for entry in os.scandir(src):  # type: os.DirEntry
@@ -84,7 +85,8 @@ def _duplicate_tree(src: Filepath, dest: Filepath) -> Iterator[Tuple[str, str, b
                           f"Skipping {entry.path}")
 
 
-def _duplicate_git_tree(src: Filepath, dest: Filepath) -> Iterator[Tuple[str, str, bool]]:
+def _duplicate_git_tree(src: Filepath, dest: Filepath
+                        ) -> Iterator[Tuple[str, str, bool]]:
     """Traverses src, finds all files registered in git and for each file or
     directory yields a path to it, its destination and whether it is a
     directory"""

--- a/src/pytest_workflow/util.py
+++ b/src/pytest_workflow/util.py
@@ -96,14 +96,18 @@ def _duplicate_git_tree(src: Filepath, dest: Filepath
     # os.path.dirname when the path is in the current directory.
     dirs: Set[str] = {''}
     for path in git_ls_files(src):
-        src_path = os.path.join(src, path)
-        dest_path = os.path.join(dest, path)
-        yield src_path, dest_path, False
-        parent = os.path.dirname(src_path)
+        # First check if parent is dir, so we can yield directories before
+        # files, to prevent creating files in non-existing directories.
+        parent = os.path.dirname(path)
         if parent not in dirs:
             src_path = os.path.join(src, parent)
             dest_path = os.path.join(dest, parent)
             yield src_path, dest_path, True
+
+        # Yield the actual file if the directory has already been yielded.
+        src_path = os.path.join(src, path)
+        dest_path = os.path.join(dest, path)
+        yield src_path, dest_path, False
 
 
 def duplicate_tree(src: Filepath, dest: Filepath,

--- a/src/pytest_workflow/util.py
+++ b/src/pytest_workflow/util.py
@@ -7,7 +7,7 @@ import subprocess  # nosec
 import sys
 import warnings
 from pathlib import Path
-from typing import Iterator, List, Set, Tuple, Union
+from typing import Callable, Iterator, List, Set, Tuple, Union
 
 Filepath = Union[str, os.PathLike]
 
@@ -133,7 +133,8 @@ def duplicate_tree(src: Filepath, dest: Filepath,
     else:
         path_iter = _duplicate_tree(src, dest)
     if symlink:
-        copy = functools.partial(os.symlink, target_is_directory=False)
+        copy: Callable[[Filepath, Filepath], None] = \
+            functools.partial(os.symlink, target_is_directory=False)
     else:
         copy = shutil.copy2  # Preserves metadata, also used by shutil.copytree
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -14,6 +14,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with pytest-workflow.  If not, see <https://www.gnu.org/licenses/
 import hashlib
+import os
 import shutil
 import tempfile
 from pathlib import Path
@@ -77,15 +78,19 @@ def test_link_tree():
 
 
 def test_link_tree_warning():
-    urandom = Path("/dev/urandom")
-    dest = Path("notexist")
-    with pytest.warns(UserWarning,
-                      match="Unsupported filetype. Skipping copying: "
-                            "'/dev/urandom' to 'notexist'."):
-        link_tree(urandom, dest)
-    # Destination should not be created
-    assert not dest.exists()
+    src_dir = Path(tempfile.mkdtemp())
+    dest_dir = Path(tempfile.mkdtemp(), "test")
 
+    not_a_file = src_dir / "not_a_file"
+    os.mkfifo(not_a_file)
+    with pytest.warns(UserWarning,
+                      match=f"Unsupported filetype for copying. Skipping"
+                            f" {not_a_file}"):
+        link_tree(src_dir, dest_dir)
+    # Destination should not be created
+    assert not (dest_dir / "not_a_file").exists()
+    shutil.rmtree(src_dir)
+    shutil.rmtree(dest_dir.parent)
 
 HASH_FILE_DIR = Path(__file__).parent / "hash_files"
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -92,6 +92,7 @@ def test_link_tree_warning():
     shutil.rmtree(src_dir)
     shutil.rmtree(dest_dir.parent)
 
+
 HASH_FILE_DIR = Path(__file__).parent / "hash_files"
 
 

--- a/tests/test_warnings.py
+++ b/tests/test_warnings.py
@@ -29,3 +29,13 @@ def test_no_warnings(testdir):
     outcomes = result.parseoutcomes()
     assert outcomes.get('warnings', 0) == 0
     shutil.rmtree(basetemp)
+
+
+def test_git_warning(testdir):
+    basetemp = tempfile.mkdtemp()
+    testdir.mkdir(".git")
+    testdir.makefile(".yml", test_a=MOO_FILE)
+    result = testdir.runpytest("--basetemp", basetemp)
+    outcomes = result.parseoutcomes()
+    assert outcomes.get('warnings') == 1
+    assert ".git dir detected" in result.stdout.str()


### PR DESCRIPTION
@DavyCats @Redmar-van-den-Berg , could you please review this? It should reduce the wear and tear on your SSDs significantly :wink:. 

Preliminary testing with Germline-DNA pipeline. Copying everything for all tests: 2.1 GB. Using `--git-aware` option: 460 MB. 
The .git folder contains a lot of cruft!

### Checklist
- [x] Pull request details were added to HISTORY.rst
