### PR TITLE
Fix deprecation warnings from pytest 7.0.0

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -9,6 +9,9 @@ Changelog
 
 version 1.7.0-dev
 ---------------------------
++ A minimum of pytest 7.0.0 is now a requirement for pytest-workflow.
+  This fixes the deprecation warnings that started on the release of pytest
+  7.0.0.
 + Throw a more descriptive error when a file copied with the --git-aware flag
   is not present on the filesystem anymore.
 

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
     # Because we use the resolve(strict=False) feature from pathlib.
     python_requires=">=3.6",
     install_requires=[
-        "pytest>=5.4.0",  # To use from_parent node instantiation.
+        "pytest>=7.0.0",  # To use pathlib Path's in pytest
         "pyyaml",
         "jsonschema"
     ],

--- a/src/pytest_workflow/plugin.py
+++ b/src/pytest_workflow/plugin.py
@@ -173,13 +173,12 @@ def pytest_configure(config: PytestConfig):
         Path(basetemp) if basetemp is not None
         else Path(tempfile.mkdtemp(prefix="pytest_workflow_")))
 
-    rootdir = Path(str(config.rootdir))
-    # Raise an error if the workflow temporary directory of the rootdir
+    # Raise an error if the workflow temporary directory of the rootpath
     # (pytest's CWD). This will lead to infinite looping and copying.
-    if is_in_dir(workflow_temp_dir, rootdir):
+    if is_in_dir(workflow_temp_dir, config.rootpath):
         raise ValueError(f"'{workflow_temp_dir}' is a subdirectory of "
-                         f"'{rootdir}'. Please select a --basetemp that is "
-                         f"not in pytest's current working directory.")
+                         f"'{config.rootpath}'. Please select a --basetemp "
+                         f"that is not in pytest's current working directory.")
 
     setattr(config, "workflow_temp_dir", workflow_temp_dir)
 

--- a/src/pytest_workflow/plugin.py
+++ b/src/pytest_workflow/plugin.py
@@ -114,12 +114,12 @@ def __pytest_workflow_cli():  # pragma: no cover
     return parser
 
 
-def pytest_collect_file(path, parent):
+def pytest_collect_file(file_path, path, parent):
     """Collection hook
     This collects the yaml files that start with "test" and end with
     .yaml or .yml"""
     if path.ext in [".yml", ".yaml"] and path.basename.startswith("test"):
-        return YamlFile.from_parent(parent, fspath=path)
+        return YamlFile.from_parent(parent, path=file_path)
     return None
 
 

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -27,33 +27,33 @@ SNAKEFILE = Path(PIPELINE_DIR, "snakemake", "SimpleSnakefile")
 
 
 @pytest.mark.functional
-def test_cromwell(testdir):
-    testdir.makefile(ext=".json", simple=SIMPLE_WDL_JSON.read_text())
-    testdir.makefile(ext=".wdl", simple=SIMPLE_WDL.read_text())
-    testdir.makefile(ext=".yml", test_wdl=SIMPLE_WDL_YAML.read_text())
-    testdir.makefile(ext=".options.json",
-                     simple=SIMPLE_WDL_OPTIONS_JSON.read_text())
-    result = testdir.runpytest("-v", "--tag", "cromwell",
-                               "--keep-workflow-wd-on-fail")
+def test_cromwell(pytester):
+    pytester.makefile(ext=".json", simple=SIMPLE_WDL_JSON.read_text())
+    pytester.makefile(ext=".wdl", simple=SIMPLE_WDL.read_text())
+    pytester.makefile(ext=".yml", test_wdl=SIMPLE_WDL_YAML.read_text())
+    pytester.makefile(ext=".options.json",
+                      simple=SIMPLE_WDL_OPTIONS_JSON.read_text())
+    result = pytester.runpytest("-v", "--tag", "cromwell",
+                                "--keep-workflow-wd-on-fail")
     exit_code = result.ret
     assert exit_code == 0
     assert "simple wdl" in result.stdout.str()
 
 
 @pytest.mark.functional
-def test_miniwdl(testdir):
-    testdir.makefile(ext=".json", simple=SIMPLE_WDL_JSON.read_text())
-    testdir.makefile(ext=".wdl", simple=SIMPLE_WDL.read_text())
-    testdir.makefile(ext=".yml", test_wdl=SIMPLE_WDL_YAML.read_text())
-    result = testdir.runpytest("-v", "--tag", "miniwdl",
-                               "--keep-workflow-wd-on-fail")
+def test_miniwdl(pytester):
+    pytester.makefile(ext=".json", simple=SIMPLE_WDL_JSON.read_text())
+    pytester.makefile(ext=".wdl", simple=SIMPLE_WDL.read_text())
+    pytester.makefile(ext=".yml", test_wdl=SIMPLE_WDL_YAML.read_text())
+    result = pytester.runpytest("-v", "--tag", "miniwdl",
+                                "--keep-workflow-wd-on-fail")
     assert result.ret == 0
 
 
 @pytest.mark.functional
-def test_snakemake(testdir):
-    testdir.makefile(ext="", SimpleSnakefile=SNAKEFILE.read_text())
-    testdir.makefile(ext=".yml", test_snakemake=SNAKEFILE_YAML.read_text())
-    result = testdir.runpytest("-v", "--keep-workflow-wd-on-fail")
+def test_snakemake(pytester):
+    pytester.makefile(ext="", SimpleSnakefile=SNAKEFILE.read_text())
+    pytester.makefile(ext=".yml", test_snakemake=SNAKEFILE_YAML.read_text())
+    result = pytester.runpytest("-v", "--keep-workflow-wd-on-fail")
     exit_code = result.ret
     assert exit_code == 0

--- a/tests/test_fail_messages.py
+++ b/tests/test_fail_messages.py
@@ -164,9 +164,9 @@ FAILURE_MESSAGE_TESTS: List[Tuple[str, str]] = [
 
 
 @pytest.mark.parametrize(["test", "message"], FAILURE_MESSAGE_TESTS)
-def test_messages(test: str, message: str, testdir):
-    testdir.makefile(".yml", textwrap.dedent(test))
+def test_messages(test: str, message: str, pytester):
+    pytester.makefile(".yml", textwrap.dedent(test))
     # Ideally this should be run in a LC_ALL=C environment. But this is not
     # possible due to multiple levels of process launching.
-    result = testdir.runpytest("-v")
+    result = pytester.runpytest("-v")
     assert message in result.stdout.str()

--- a/tests/test_miscellaneous_crashes.py
+++ b/tests/test_miscellaneous_crashes.py
@@ -17,10 +17,10 @@
 from .test_success_messages import SIMPLE_ECHO
 
 
-def test_same_name_different_files(testdir):
-    testdir.makefile(".yml", test_a=SIMPLE_ECHO)
-    testdir.makefile(".yml", test_b=SIMPLE_ECHO)
-    result = testdir.runpytest()
+def test_same_name_different_files(pytester):
+    pytester.makefile(".yml", test_a=SIMPLE_ECHO)
+    pytester.makefile(".yml", test_b=SIMPLE_ECHO)
+    result = pytester.runpytest()
     assert result.ret != 0
     assert ("Workflow name 'simple echo' used more than once"
             in result.stdout.str())

--- a/tests/test_multithreading.py
+++ b/tests/test_multithreading.py
@@ -36,10 +36,10 @@ MULTHITHREADED_TEST = [
 
 
 @pytest.mark.parametrize(["threads"], [(1,), (2,), (4,)])
-def test_multithreaded(threads, testdir):
+def test_multithreaded(threads, pytester):
     test = MULTHITHREADED_TEST
     test_number = len(test)
-    testdir.makefile(".yml", test=yaml.safe_dump(test))
+    pytester.makefile(".yml", test=yaml.safe_dump(test))
 
     # Calculate how many iterations are needed to process all the tests
     # For example: 4 tests with 2 threads. 2 can be finished simultaneously
@@ -49,7 +49,7 @@ def test_multithreaded(threads, testdir):
                   else test_number // threads + 1)
 
     start_time = time.time()
-    testdir.runpytest("-v", "--wt", str(threads))
+    pytester.runpytest("-v", "--wt", str(threads))
     end_time = time.time()
     completion_time = end_time - start_time
     # If the completion time is shorter than (iterations * SLEEP_TIME), too

--- a/tests/test_success_messages.py
+++ b/tests/test_success_messages.py
@@ -110,7 +110,7 @@ SUCCESS_MESSAGES = [
 
 @pytest.fixture(scope="session")
 def succeeding_tests_output(tmp_path_factory: pytest.TempPathFactory):
-    """This fixture was written because the testdir function has a default
+    """This fixture was written because the pytester function has a default
     scope of 'function'. This is very inefficient when testing multiple
     success messages in the output as the whole test yaml with all commands
     has to be run again.
@@ -137,8 +137,8 @@ def test_message_success_no_errors_or_fails(succeeding_tests_output):
     assert "FAIL" not in succeeding_tests_output
 
 
-def test_message_directory_kept_no_errors_or_fails(testdir):
-    testdir.makefile(".yml", test=SUCCEEDING_TESTS_YAML)
-    result = testdir.runpytest("-v", "--keep-workflow-wd")
+def test_message_directory_kept_no_errors_or_fails(pytester):
+    pytester.makefile(".yml", test=SUCCEEDING_TESTS_YAML)
+    result = pytester.runpytest("-v", "--keep-workflow-wd")
     assert "ERROR" not in result.stdout.str()
     assert "FAIL" not in result.stdout.str()

--- a/tests/test_success_messages.py
+++ b/tests/test_success_messages.py
@@ -20,8 +20,6 @@ import subprocess  # nosec
 import textwrap
 from pathlib import Path
 
-from _pytest.tmpdir import TempdirFactory
-
 import pytest
 
 MOO_FILE = textwrap.dedent("""\
@@ -111,7 +109,7 @@ SUCCESS_MESSAGES = [
 
 
 @pytest.fixture(scope="session")
-def succeeding_tests_output(tmpdir_factory: TempdirFactory):
+def succeeding_tests_output(tmpdir_factory):
     """This fixture was written because the testdir function has a default
     scope of 'function'. This is very inefficient when testing multiple
     success messages in the output as the whole test yaml with all commands

--- a/tests/test_success_messages.py
+++ b/tests/test_success_messages.py
@@ -109,13 +109,13 @@ SUCCESS_MESSAGES = [
 
 
 @pytest.fixture(scope="session")
-def succeeding_tests_output(tmpdir_factory):
+def succeeding_tests_output(tmp_path_factory: pytest.TempPathFactory):
     """This fixture was written because the testdir function has a default
     scope of 'function'. This is very inefficient when testing multiple
     success messages in the output as the whole test yaml with all commands
     has to be run again.
     This fixture runs the succeeding tests once with pytest -v"""
-    tempdir = str(tmpdir_factory.mktemp("succeeding_tests"))
+    tempdir = tmp_path_factory.mktemp("succeeding_tests")
     test_file = Path(tempdir, "test_succeeding.yml")
     with test_file.open("w") as file_handler:
         file_handler.write(SUCCEEDING_TESTS_YAML)

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -39,35 +39,35 @@ TAG_TESTS = textwrap.dedent("""\
 """)
 
 
-def test_name_tag_with_space(testdir):
-    testdir.makefile(".yml", test_tags=TAG_TESTS)
-    result = testdir.runpytest("-v", "--tag", "three again").stdout.str()
+def test_name_tag_with_space(pytester):
+    pytester.makefile(".yml", test_tags=TAG_TESTS)
+    result = pytester.runpytest("-v", "--tag", "three again").stdout.str()
     assert "three again" in result
     assert "four" not in result
     assert "nine" not in result
 
 
-def test_name_tag(testdir):
-    testdir.makefile(".yml", test_tags=TAG_TESTS)
-    result = testdir.runpytest("-v", "--tag", "three").stdout.str()
+def test_name_tag(pytester):
+    pytester.makefile(".yml", test_tags=TAG_TESTS)
+    result = pytester.runpytest("-v", "--tag", "three").stdout.str()
     assert "three" in result
     assert "three again" not in result
     assert "four" not in result
     assert "nine" not in result
 
 
-def test_category_tag(testdir):
-    testdir.makefile(".yml", test_tags=TAG_TESTS)
-    result = testdir.runpytest("-v", "--tag", "odd").stdout.str()
+def test_category_tag(pytester):
+    pytester.makefile(".yml", test_tags=TAG_TESTS)
+    result = pytester.runpytest("-v", "--tag", "odd").stdout.str()
     assert "three" in result
     assert "three again" in result
     assert "nine" in result
     assert "four" not in result
 
 
-def test_category_tag2(testdir):
-    testdir.makefile(".yml", test_tags=TAG_TESTS)
-    result = testdir.runpytest("-v", "--tag", "even").stdout.str()
+def test_category_tag2(pytester):
+    pytester.makefile(".yml", test_tags=TAG_TESTS)
+    result = pytester.runpytest("-v", "--tag", "even").stdout.str()
     assert "three" not in result
     assert "three again" not in result
     assert "four" in result

--- a/tests/test_threading_errors.py
+++ b/tests/test_threading_errors.py
@@ -19,13 +19,13 @@
 import textwrap
 
 
-def test_shlex_error(testdir):
+def test_shlex_error(pytester):
     test = textwrap.dedent("""\
     - name: wrong command
       command: a command with a dangling double-quote"
     """)
-    testdir.makefile(".yml", test=test)
-    result = testdir.runpytest("-v")
+    pytester.makefile(".yml", test=test)
+    result = pytester.runpytest("-v")
     assert "shlex" in result.stdout.str()
     assert "ValueError: No closing quotation" in result.stdout.str()
     assert "'wrong command' python error during start" in result.stdout.str()

--- a/tests/test_warnings.py
+++ b/tests/test_warnings.py
@@ -22,20 +22,20 @@ from .test_success_messages import MOO_FILE
 
 # Add a test to make sure no deprecation, or other warnings occur due to
 # changes in upstream libraries.
-def test_no_warnings(testdir):
+def test_no_warnings(pytester):
     basetemp = tempfile.mkdtemp()
-    testdir.makefile(".yml", test_a=MOO_FILE)
-    result = testdir.runpytest("--basetemp", basetemp)
+    pytester.makefile(".yml", test_a=MOO_FILE)
+    result = pytester.runpytest("--basetemp", basetemp)
     outcomes = result.parseoutcomes()
     assert outcomes.get('warnings', 0) == 0
     shutil.rmtree(basetemp)
 
 
-def test_git_warning(testdir):
+def test_git_warning(pytester):
     basetemp = tempfile.mkdtemp()
-    testdir.mkdir(".git")
-    testdir.makefile(".yml", test_a=MOO_FILE)
-    result = testdir.runpytest("--basetemp", basetemp)
+    pytester.mkdir(".git")
+    pytester.makefile(".yml", test_a=MOO_FILE)
+    result = pytester.runpytest("--basetemp", basetemp)
     outcomes = result.parseoutcomes()
     assert outcomes.get('warnings') == 1
     assert ".git dir detected" in result.stdout.str()

--- a/tests/test_workflow_dependent_tests.py
+++ b/tests/test_workflow_dependent_tests.py
@@ -40,28 +40,28 @@ def test_hook_impl():
 
 
 @pytest.mark.parametrize("test", [TEST_HOOK_ARGS])
-def test_not_skipped(test, testdir):
-    testdir.makefile(".yml", test_simple=SIMPLE_ECHO)
-    testdir.makefile(".py", test_hook=test)
-    result = testdir.runpytest()
+def test_not_skipped(test, pytester):
+    pytester.makefile(".yml", test_simple=SIMPLE_ECHO)
+    pytester.makefile(".py", test_hook=test)
+    result = pytester.runpytest()
     result.assert_outcomes(passed=5)
 
 
-def test_name_use_is_deprecated(testdir):
-    testdir.makefile(".py", test_hook=TEST_HOOK_KWARGS)
-    testdir.makefile(".yml", test_simple=SIMPLE_ECHO)
-    result = testdir.runpytest().stdout.str()
+def test_name_use_is_deprecated(pytester):
+    pytester.makefile(".py", test_hook=TEST_HOOK_KWARGS)
+    pytester.makefile(".yml", test_simple=SIMPLE_ECHO)
+    result = pytester.runpytest().stdout.str()
     assert "Use pytest.mark.workflow('workflow_name') instead." in result
     assert "DeprecationWarning" in result
 
 
 @pytest.mark.parametrize("test", [TEST_HOOK_ARGS])
-def test_skipped(test, testdir):
-    testdir.makefile(".yml", test_simple=SIMPLE_ECHO)
-    testdir.makefile(".py", test_hook=test)
+def test_skipped(test, pytester):
+    pytester.makefile(".yml", test_simple=SIMPLE_ECHO)
+    pytester.makefile(".py", test_hook=test)
     # No workflow will run because the tag does not match
     # ``-r s`` gives the reason why a test was skipped.
-    result = testdir.runpytest("-v", "-r", "s", "--tag", "flaksdlkad")
+    result = pytester.runpytest("-v", "-r", "s", "--tag", "flaksdlkad")
     result.assert_outcomes(skipped=1)
     assert "'simple echo' has not run." in result.stdout.str()
 
@@ -77,30 +77,30 @@ def test_fixture_impl(workflow_dir):
 
 
 @pytest.mark.parametrize("test", [TEST_FIXTURE_ARGS])
-def test_workflow_dir_arg(test, testdir):
+def test_workflow_dir_arg(test, pytester):
     # Call the test, `test_asimple` because tests are run alphabetically.
     # This will detect if the workflow dir has been removed.
-    testdir.makefile(".yml", test_asimple=SIMPLE_ECHO)
-    testdir.makefile(".py", test_fixture=test)
-    result = testdir.runpytest()
+    pytester.makefile(".yml", test_asimple=SIMPLE_ECHO)
+    pytester.makefile(".py", test_fixture=test)
+    result = pytester.runpytest()
     result.assert_outcomes(passed=5, failed=0, errors=0, skipped=0)
 
 
 @pytest.mark.parametrize("test", [TEST_FIXTURE_ARGS])
-def test_workflow_dir_arg_skipped(test, testdir):
+def test_workflow_dir_arg_skipped(test, pytester):
     """Run this test to check if this does not run into fixture request
     errors"""
-    testdir.makefile(".yml", test_asimple=SIMPLE_ECHO)
-    testdir.makefile(".py", test_fixture=test)
-    result = testdir.runpytest("-v", "-r", "s", "--tag", "flaksdlkad")
+    pytester.makefile(".yml", test_asimple=SIMPLE_ECHO)
+    pytester.makefile(".py", test_fixture=test)
+    result = pytester.runpytest("-v", "-r", "s", "--tag", "flaksdlkad")
     result.assert_outcomes(skipped=1)
 
 
 @pytest.mark.parametrize("test", [TEST_FIXTURE_ARGS])
-def test_mark_not_unknown(test, testdir):
-    testdir.makefile(".yml", test_asimple=SIMPLE_ECHO)
-    testdir.makefile(".py", test_fixture=test)
-    result = testdir.runpytest("-v")
+def test_mark_not_unknown(test, pytester):
+    pytester.makefile(".yml", test_asimple=SIMPLE_ECHO)
+    pytester.makefile(".py", test_fixture=test)
+    result = pytester.runpytest("-v")
     assert "PytestUnknownMarkWarning" not in result.stdout.str()
 
 
@@ -113,12 +113,12 @@ def test_fixture_impl(workflow_dir):
 """)
 
 
-def test_workflow_not_exist_dir_arg(testdir):
+def test_workflow_not_exist_dir_arg(pytester):
     """Run this test to check if this does not run into fixture request
     errors"""
-    testdir.makefile(".yml", test_asimple=SIMPLE_ECHO)
-    testdir.makefile(".py", test_fixture=TEST_FIXTURE_WORKFLOW_NOT_EXIST)
-    result = testdir.runpytest("-v", "-r", "s")
+    pytester.makefile(".yml", test_asimple=SIMPLE_ECHO)
+    pytester.makefile(".py", test_fixture=TEST_FIXTURE_WORKFLOW_NOT_EXIST)
+    result = pytester.runpytest("-v", "-r", "s")
     result.assert_outcomes(skipped=1, passed=4)
     assert "'shoobiedoewap' has not run." in result.stdout.str()
 
@@ -131,12 +131,12 @@ def test_fixture_impl(workflow_dir):
 """)
 
 
-def test_fixture_unmarked_test(testdir):
+def test_fixture_unmarked_test(pytester):
     """Run this test to check if this does not run into fixture request
     errors"""
-    testdir.makefile(".yml", test_asimple=SIMPLE_ECHO)
-    testdir.makefile(".py", test_fixture=TEST_FIXTURE_UNMARKED_TEST)
-    result = testdir.runpytest("-v", "-r", "s")
+    pytester.makefile(".yml", test_asimple=SIMPLE_ECHO)
+    pytester.makefile(".py", test_fixture=TEST_FIXTURE_UNMARKED_TEST)
+    result = pytester.runpytest("-v", "-r", "s")
     assert ("workflow_dir can only be requested in tests marked with "
             "the workflow mark.") in result.stdout.str()
 
@@ -151,12 +151,12 @@ def test_fixture_impl(workflow_dir):
 """)
 
 
-def test_mark_wrong_key_with_fixture(testdir):
+def test_mark_wrong_key_with_fixture(pytester):
     """Run this test to check if this does not run into fixture request
     errors"""
-    testdir.makefile(".yml", test_asimple=SIMPLE_ECHO)
-    testdir.makefile(".py", test_fixture=TEST_MARK_WRONG_KEY)
-    result = testdir.runpytest("-v", "-r", "s")
+    pytester.makefile(".yml", test_asimple=SIMPLE_ECHO)
+    pytester.makefile(".py", test_fixture=TEST_MARK_WRONG_KEY)
+    result = pytester.runpytest("-v", "-r", "s")
     assert ("A workflow name or names should be defined in the "
             "workflow marker of test_fixture.py::test_fixture_impl"
             ) in result.stdout.str()
@@ -164,7 +164,7 @@ def test_mark_wrong_key_with_fixture(testdir):
     result.assert_outcomes(passed=0, failed=0, skipped=0, errors=1)
 
 
-def test_fixture_usable_for_file_tests(testdir):
+def test_fixture_usable_for_file_tests(pytester):
     test_workflow = textwrap.dedent("""\
     - name: number files
       command: >-
@@ -189,13 +189,13 @@ def test_fixture_usable_for_file_tests(testdir):
         assert int(number_file_content) % 3 == 0
     """)
 
-    testdir.makefile(".yml", test_aworkflow=test_workflow)
-    testdir.makefile(".py", test_div=test_div_by_three)
-    result = testdir.runpytest("-v")
+    pytester.makefile(".yml", test_aworkflow=test_workflow)
+    pytester.makefile(".py", test_div=test_div_by_three)
+    result = pytester.runpytest("-v")
     result.assert_outcomes(passed=4, failed=0, skipped=0, errors=0)
 
 
-def test_same_custom_test_multiple_times(testdir):
+def test_same_custom_test_multiple_times(pytester):
     test_workflow = textwrap.dedent("""\
     - name: one_two_three
       command: >-
@@ -226,9 +226,9 @@ def test_same_custom_test_multiple_times(testdir):
         assert int(number_file.read_text()) % 3 == 0
     """)
 
-    testdir.makefile(".yml", test_aworkflow=test_workflow)
-    testdir.makefile(".py", test_div=test_div_by_three)
-    result = testdir.runpytest("-v")
+    pytester.makefile(".yml", test_aworkflow=test_workflow)
+    pytester.makefile(".py", test_div=test_div_by_three)
+    result = pytester.runpytest("-v")
     result.assert_outcomes(passed=9, failed=0, skipped=0, errors=0)
 
 
@@ -263,19 +263,19 @@ def test_div_by_three(workflow_dir):
 """)
 
 
-def test_same_custom_test_multiple_times_one_error(testdir):
-    testdir.makefile(".yml", test_aworkflow=TEST_WORKFLOWS)
-    testdir.makefile(".py", test_div=TEST_DIV_BY_THREE)
-    result = testdir.runpytest("-v")
+def test_same_custom_test_multiple_times_one_error(pytester):
+    pytester.makefile(".yml", test_aworkflow=TEST_WORKFLOWS)
+    pytester.makefile(".py", test_div=TEST_DIV_BY_THREE)
+    result = pytester.runpytest("-v")
     result.assert_outcomes(passed=8, failed=1, skipped=0, errors=0)
     assert ("test_div.py::test_div_by_three[two_three_five] FAILED "
             in result.stdout.str())
 
 
-def test_custom_tests_properly_skipped(testdir):
-    testdir.makefile(".yml", test_aworkflow=TEST_WORKFLOWS)
-    testdir.makefile(".py", test_div=TEST_DIV_BY_THREE)
-    result = testdir.runpytest("-v", "--tag", "one_two_three")
+def test_custom_tests_properly_skipped(pytester):
+    pytester.makefile(".yml", test_aworkflow=TEST_WORKFLOWS)
+    pytester.makefile(".py", test_div=TEST_DIV_BY_THREE)
+    result = pytester.runpytest("-v", "--tag", "one_two_three")
     result.assert_outcomes(passed=3, failed=0, skipped=2, errors=0)
     assert ("test_div.py::test_div_by_three[two_three_five] SKIPPED "
             in result.stdout.str())


### PR DESCRIPTION
### Checklist
- [x] Pull request details were added to HISTORY.rst

Pytest is switching away from its own `Path` implementation, using `pathlib.Path` instead. This came with some deprecation warnings.