### PR TITLE
allow passing through host env vars to executing commands

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -14,6 +14,8 @@ version 1.7.0-dev
   7.0.0.
 + Throw a more descriptive error when a file copied with the --git-aware flag
   is not present on the filesystem anymore.
++ Allow passing environment variables from the host to the executing command
+  with ``pass_through_env_vars``.
 
 version 1.6.0
 ---------------------------

--- a/src/pytest_workflow/plugin.py
+++ b/src/pytest_workflow/plugin.py
@@ -19,6 +19,7 @@ import argparse
 import shutil
 import tempfile
 import warnings
+import os
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -400,7 +401,8 @@ class WorkflowTestsCollector(pytest.Collector):
         # Create a workflow and make sure it runs in the tempdir
         workflow = Workflow(command=self.workflow_test.command,
                             cwd=tempdir,
-                            name=self.workflow_test.name)
+                            name=self.workflow_test.name,
+                            env={k: os.getenv(k) for k in self.workflow_test.pass_through_env_vars})
 
         # Add the workflow to the workflow queue.
         self.config.workflow_queue.put(workflow)

--- a/src/pytest_workflow/plugin.py
+++ b/src/pytest_workflow/plugin.py
@@ -16,10 +16,10 @@
 
 """core functionality of pytest-workflow plugin"""
 import argparse
+import os
 import shutil
 import tempfile
 import warnings
-import os
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -402,7 +402,8 @@ class WorkflowTestsCollector(pytest.Collector):
         workflow = Workflow(command=self.workflow_test.command,
                             cwd=tempdir,
                             name=self.workflow_test.name,
-                            env={k: os.getenv(k) for k in self.workflow_test.pass_through_env_vars})
+                            env={k: os.getenv(k) for k
+                                 in self.workflow_test.pass_through_env_vars})
 
         # Add the workflow to the workflow queue.
         self.config.workflow_queue.put(workflow)

--- a/src/pytest_workflow/schema.py
+++ b/src/pytest_workflow/schema.py
@@ -167,7 +167,8 @@ class WorkflowTest(object):
         :param stdout: a ContentTest object
         :param stderr: a ContentTest object
         :param files: a list of FileTest objects
-        :param pass_through_env_vars: a list of environment variables to pass through to the executing command
+        :param pass_through_env_vars: a list of environment variables
+        to pass through to the executing command
         """
         self.name = name
         self.command = command

--- a/src/pytest_workflow/schema.py
+++ b/src/pytest_workflow/schema.py
@@ -157,7 +157,8 @@ class WorkflowTest(object):
                  exit_code: int = DEFAULT_EXIT_CODE,
                  stdout: ContentTest = ContentTest(),
                  stderr: ContentTest = ContentTest(),
-                 files: Optional[List[FileTest]] = None):
+                 files: Optional[List[FileTest]] = None,
+                 pass_through_env_vars: Optional[List[str]] = None):
         """
         Create a WorkflowTest object.
         :param name: The name of the test
@@ -166,6 +167,7 @@ class WorkflowTest(object):
         :param stdout: a ContentTest object
         :param stderr: a ContentTest object
         :param files: a list of FileTest objects
+        :param pass_through_env_vars: a list of environment variables to pass through to the executing command
         """
         self.name = name
         self.command = command
@@ -174,6 +176,7 @@ class WorkflowTest(object):
         self.stderr = stderr
         self.files = files or []
         self.tags = tags or []
+        self.pass_through_env_vars = pass_through_env_vars or []
 
     @classmethod
     def from_schema(cls, schema: dict):
@@ -188,5 +191,6 @@ class WorkflowTest(object):
             exit_code=schema.get("exit_code", DEFAULT_EXIT_CODE),
             stdout=ContentTest(**schema.get("stdout", {})),
             stderr=ContentTest(**schema.get("stderr", {})),
-            files=test_files
+            files=test_files,
+            pass_through_env_vars=schema.get("pass_through_env_vars", [])
         )

--- a/src/pytest_workflow/schema/schema.json
+++ b/src/pytest_workflow/schema/schema.json
@@ -147,6 +147,13 @@
           ],
           "additionalProperties": false
         }
+      },
+      "pass_through_env_vars": {
+        "description": "Environment variables to pass to the running workflow",
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
       }
     },
     "required": [

--- a/src/pytest_workflow/workflow.py
+++ b/src/pytest_workflow/workflow.py
@@ -27,7 +27,7 @@ import tempfile
 import threading
 import time
 from pathlib import Path
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 
 class Workflow(object):
@@ -35,7 +35,8 @@ class Workflow(object):
     def __init__(self,
                  command: str,
                  cwd: Optional[Path] = None,
-                 name: Optional[str] = None):
+                 name: Optional[str] = None,
+                 env: Optional[Dict[str, str]] = None):
         """
         Initiates a workflow object
         :param command: The string that represents the command to be run
@@ -51,6 +52,7 @@ class Workflow(object):
         # for emptiness.
         self.name = name or command.split()[0]
         self.cwd = cwd or Path()
+        self.env = env
         # For long running workflows it is best to save the stdout and stderr
         # to a file which can be checked with ``tail -f``.
         # stdout and stderr will be written to a tempfile if no CWD is given
@@ -83,7 +85,7 @@ class Workflow(object):
                     sub_process_args = shlex.split(self.command)
                     self._popen = subprocess.Popen(  # nosec: Shell is not enabled. # noqa
                         sub_process_args, stdout=stdout_h,
-                        stderr=stderr_h, cwd=str(self.cwd))
+                        stderr=stderr_h, cwd=str(self.cwd), env=self.env)
                 except Exception as error:
                     # Append the error so it can be raised in the main thread.
                     self.errors.append(error)

--- a/tests/functional/test_env.yml
+++ b/tests/functional/test_env.yml
@@ -1,0 +1,7 @@
+- name: "Test env"
+  command: "env"
+  pass_through_env_vars:
+    - "PATH"
+  stdout:
+    contains:
+      - /bin


### PR DESCRIPTION
Commands are executed with an empty env. This PR adds the ability to pass env vars through to the workflow (e.g. aws credentials).

Still, using a command like `echo $HOME` won't work, because this library uses `shlex` which would pass the literal unexpanded `$HOME` through to `subprocess.Popen`. Nonetheless, it works if e.g. you set your command to `env`.

I intentionally only added `pass_through_env_vars` (as opposed to an arbitrary dict of literal env vars to pass through) - seemed simpler. I did at some point convert it to `env` so if we ever wanted to add such functionality, we could.

The test relies on having `/bin` as a substring of your `PATH`. This was the best way I could come up with to test this.

Lastly! I'm pretty open to e.g. changing the var name or structure.

Thanks!

### Checklist
- [x] Pull request details were added to HISTORY.rst
