### PR TITLE
Fix crash when stderr bytes is not properly not aligned with the encoding

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -7,6 +7,12 @@ Changelog
 .. This document is user facing. Please word the changes in such a way
 .. that users understand how the changes affect the new version.
 
+version 2.1.0-dev
+---------------------------
++ Fixed a bug where pytest-workflow would crash on logs that used non-ASCII
+  characters where the chunk of size ``--stderr-bytes`` did not properly align
+  with the used encoding.
+
 version 2.0.0
 ---------------------------
 This major release greatly cleans up the output of pytest-workflow in case of

--- a/src/pytest_workflow/util.py
+++ b/src/pytest_workflow/util.py
@@ -212,6 +212,8 @@ def file_md5sum(filepath: Path, block_size=64 * 1024) -> str:
 
 
 def decode_unaligned(data: bytes, encoding: Optional[str] = None):
+    if encoding is None:
+        encoding = sys.getdefaultencoding()
     for offset in range(4):
         try:
             decoded = data[offset:].decode(encoding=encoding, errors="strict")

--- a/src/pytest_workflow/util.py
+++ b/src/pytest_workflow/util.py
@@ -7,7 +7,7 @@ import subprocess
 import sys
 import warnings
 from pathlib import Path
-from typing import Callable, Iterator, List, Set, Tuple, Union
+from typing import Callable, Iterator, List, Optional, Set, Tuple, Union
 
 Filepath = Union[str, os.PathLike]
 
@@ -209,3 +209,15 @@ def file_md5sum(filepath: Path, block_size=64 * 1024) -> str:
         for block in iter(lambda: file_handler.read(block_size), b''):
             hasher.update(block)
     return hasher.hexdigest()
+
+
+def decode_unaligned(data: bytes, encoding: Optional[str] = None):
+    for offset in range(4):
+        try:
+            decoded = data[offset:].decode(encoding=encoding, errors="strict")
+            return decoded
+        except UnicodeDecodeError as e:
+            continue
+    # When no return happens in the loop, decode again. This will throw an
+    # error that is not caught and shown to the user.
+    return data.decode(encoding=encoding)

--- a/src/pytest_workflow/util.py
+++ b/src/pytest_workflow/util.py
@@ -218,7 +218,7 @@ def decode_unaligned(data: bytes, encoding: Optional[str] = None):
         try:
             decoded = data[offset:].decode(encoding=encoding, errors="strict")
             return decoded
-        except UnicodeDecodeError as e:
+        except UnicodeDecodeError:
             continue
     # When no return happens in the loop, decode again. This will throw an
     # error that is not caught and shown to the user.

--- a/tests/test_miscellaneous_crashes.py
+++ b/tests/test_miscellaneous_crashes.py
@@ -16,7 +16,10 @@
 
 import textwrap
 
+from pytest import ExitCode
+
 from .test_success_messages import SIMPLE_ECHO
+
 
 def test_same_name_different_files(pytester):
     pytester.makefile(".yml", test_a=SIMPLE_ECHO)
@@ -37,5 +40,4 @@ def test_non_ascii_logs_stderr_bytes(pytester):
     """)
     pytester.makefile(".yml", test_non_ascii=test)
     result = pytester.runpytest("--stderr-bytes", "7")
-    assert result.ret != 0
-    assert not "DecodeError" in result.stdout.str()
+    assert result.ret == ExitCode.TESTS_FAILED

--- a/tests/test_miscellaneous_crashes.py
+++ b/tests/test_miscellaneous_crashes.py
@@ -14,8 +14,9 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with pytest-workflow.  If not, see <https://www.gnu.org/licenses/
 
-from .test_success_messages import SIMPLE_ECHO
+import textwrap
 
+from .test_success_messages import SIMPLE_ECHO
 
 def test_same_name_different_files(pytester):
     pytester.makefile(".yml", test_a=SIMPLE_ECHO)
@@ -27,3 +28,14 @@ def test_same_name_different_files(pytester):
     conflicting_message = (
         "Conflicting tests: test_b.yml::simple echo, test_a.yml::simple echo.")
     assert conflicting_message in result.stdout.str()
+
+
+def test_non_ascii_logs_stderr_bytes(pytester):
+    test = textwrap.dedent("""
+    - name: print non-ascii
+      command: bash -c 'printf èèèèèèèèè && exit 1'
+    """)
+    pytester.makefile(".yml", test_non_ascii=test)
+    result = pytester.runpytest("--stderr-bytes", "7")
+    assert result.ret != 0
+    assert not "DecodeError" in result.stdout.str()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -240,3 +240,9 @@ def test_decode_unaligned(offset, encoding):
     data = string.encode(encoding or sys.getdefaultencoding())
     decoded = decode_unaligned(data[offset:], encoding)
     assert string.endswith(decoded)
+
+
+def test_decode_unaligned_wrong_encoding_throws_error():
+    data = "hello".encode("utf-8")
+    with pytest.raises(UnicodeDecodeError):
+        decode_unaligned(data, "utf-32-le")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -14,6 +14,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with pytest-workflow.  If not, see <https://www.gnu.org/licenses/
 import hashlib
+import itertools
 import os
 import shutil
 import subprocess
@@ -22,8 +23,8 @@ from pathlib import Path
 
 import pytest
 
-from pytest_workflow.util import duplicate_tree, file_md5sum, \
-    git_check_submodules_cloned, git_root, \
+from pytest_workflow.util import decode_unaligned, duplicate_tree, \
+    file_md5sum, git_check_submodules_cloned, git_root, \
     is_in_dir, link_tree, replace_whitespace
 
 WHITESPACE_TESTS = [
@@ -227,3 +228,10 @@ def test_duplicate_git_tree_submodule_symlinks(git_repo_with_submodules):
     assert link.exists()
     assert link.is_symlink()
     assert link.resolve() == dest / "bird" / "sub"
+
+
+@pytest.mark.parametrize(["offset", "encoding"],
+                         itertools.product(range(4),
+                                           ("utf-8", "utf-16", "utf-32")))
+def test_decode_unaligned(offset, encoding):
+    string = "èèèèèèèèèèè"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -18,6 +18,7 @@ import itertools
 import os
 import shutil
 import subprocess
+import sys
 import tempfile
 from pathlib import Path
 
@@ -231,7 +232,11 @@ def test_duplicate_git_tree_submodule_symlinks(git_repo_with_submodules):
 
 
 @pytest.mark.parametrize(["offset", "encoding"],
-                         itertools.product(range(4),
-                                           ("utf-8", "utf-16", "utf-32")))
+                         list(itertools.product(
+                             range(4), (None, "utf-8", "utf-16", "utf-32"))
+                         ))
 def test_decode_unaligned(offset, encoding):
     string = "èèèèèèèèèèè"
+    data = string.encode(encoding or sys.getdefaultencoding())
+    decoded = decode_unaligned(data[offset:], encoding)
+    assert string.endswith(decoded)


### PR DESCRIPTION
### Checklist
- [x] Pull request details were added to HISTORY.rst

Fixes #167 

In the log given at that bug it shows that the progress bar of snakemake contains very large arrays of non-ASCII characters. This makes an error caused by stderr-bytes quite likely. Therefore I will create a new release after this is merged.

