### PR TITLE
Add extract_md5sum check

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -9,9 +9,9 @@ Changelog
 
 version 2.1.0-dev
 ---------------------------
-+ Add md5sum checking on unzipped contents of gzipped output files. Gzipped
-  files contain a timestamp which makes it hard to directly compare the md5sums
-  of gzipped files.
++ Add extract_md5sum check on uncompressed contents of compressed output files.
+  Gzipped files contain a timestamp which makes it hard to directly compare the
+  md5sums of gzipped files.
 + Document naming conventions for Python test discovery
 
 version 2.0.1

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -9,7 +9,10 @@ Changelog
 
 version 2.1.0-dev
 ---------------------------
-* Document naming conventions for Python test discovery
++ Add md5sum checking on unzipped contents of gzipped output files. Gzipped
+  files contain a timestamp which makes it hard to directly compare the md5sums
+  of gzipped files.
++ Document naming conventions for Python test discovery
 
 version 2.0.1
 ---------------------------

--- a/docs/writing_tests.rst
+++ b/docs/writing_tests.rst
@@ -64,6 +64,7 @@ Test options
       - path: "TomCruise.txt.gz"       # Gzipped files can also be searched, provided their extension is '.gz'
         contains:
           - "starring"
+        ungzip_md5sum: e27c52f6b5f8152aa3ef58be7bdacc4d   # Md5sum of the ungzipped file (optional)
     stderr:                            # Options for testing stderr (optional)
       contains:                        # A list of strings which should be in stderr (optional)
         - "BSOD error, please contact the IT crowd"

--- a/docs/writing_tests.rst
+++ b/docs/writing_tests.rst
@@ -64,7 +64,7 @@ Test options
       - path: "TomCruise.txt.gz"       # Gzipped files can also be searched, provided their extension is '.gz'
         contains:
           - "starring"
-        ungzip_md5sum: e27c52f6b5f8152aa3ef58be7bdacc4d   # Md5sum of the ungzipped file (optional)
+        extract_md5sum: e27c52f6b5f8152aa3ef58be7bdacc4d   # Md5sum of the uncompressed file (optional)
     stderr:                            # Options for testing stderr (optional)
       contains:                        # A list of strings which should be in stderr (optional)
         - "BSOD error, please contact the IT crowd"
@@ -89,6 +89,12 @@ The above YAML file contains all the possible options for a workflow test.
 Please see the `Python documentation on regular expressions
 <https://docs.python.org/3/library/re.html>`_ to see how Python handles escape
 sequences.
+
+The ``extract_md5sum`` option is used to uncompress a file and then compare
+the md5sum of the uncompressed file with the supplied md5sum. This option is
+particularly useful when testing gzipped files, which may contain a file
+creation timestamp in the gzip header. The supported compressed file
+formats for this option are gzip, bzip2, xz and Zstandard.
 
 .. note::
     Workflow names must be unique. Pytest workflow will crash when multiple

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 pyyaml
 pytest>=7.0.0
 jsonschema
+xopen>=1.7.0
+zstandard

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,9 @@ setup(
     install_requires=[
         "pytest>=7.0.0",  # To use pathlib Path's in pytest
         "pyyaml",
-        "jsonschema"
+        "jsonschema",
+        "xopen>=1.4.0",
+        "zstandard",
     ],
     # This line makes sure the plugin is automatically loaded when it is
     # installed in the same environment as pytest. No need to configure

--- a/src/pytest_workflow/file_tests.py
+++ b/src/pytest_workflow/file_tests.py
@@ -22,7 +22,7 @@ import pytest
 
 from .content_tests import ContentTestCollector
 from .schema import FileTest
-from .util import file_md5sum
+from .util import file_md5sum, gzip_md5sum
 from .workflow import Workflow
 
 
@@ -76,7 +76,16 @@ class FileTestCollector(pytest.Collector):
                 parent=self,
                 filepath=filepath,
                 md5sum=self.filetest.md5sum,
-                workflow=self.workflow)]
+                workflow=self.workflow,
+                ungzip=False)]
+
+        if self.filetest.ungzip_md5sum:
+            tests += [FileMd5.from_parent(
+                parent=self,
+                filepath=filepath,
+                md5sum=self.filetest.ungzip_md5sum,
+                workflow=self.workflow,
+                ungzip=True)]
 
         return tests
 
@@ -119,20 +128,22 @@ class FileExists(pytest.Item):
 
 class FileMd5(pytest.Item):
     def __init__(self, parent: pytest.Collector, filepath: Path,
-                 md5sum: str, workflow: Workflow):
+                 md5sum: str, workflow: Workflow, ungzip: bool):
         """
         Create a tests for the file md5sum.
         :param parent: The collector that started this item
         :param filepath: The path to the file
         :param md5sum:  The expected md5sum
         :param workflow: The workflow running to generate the file
+        :param ungzip: Whether the file should be ungzipped before calculating
         """
-        name = "md5sum"
+        name = "unzip_md5sum" if ungzip else "md5sum"
         super().__init__(name, parent)
         self.filepath = filepath
         self.expected_md5sum = md5sum
         self.observed_md5sum = None
         self.workflow = workflow
+        self.ungzip = ungzip
 
     def runtest(self):
         # Wait for the workflow to finish before we check the md5sum of a file.
@@ -140,11 +151,14 @@ class FileMd5(pytest.Item):
         if not self.workflow.matching_exitcode():
             pytest.skip(f"'{self.parent.workflow.name}' did not exit with"
                         f"desired exit code.")
-        self.observed_md5sum = file_md5sum(self.filepath)
+        sum_func = gzip_md5sum if self.ungzip else file_md5sum
+        self.observed_md5sum = sum_func(self.filepath)
         assert self.observed_md5sum == self.expected_md5sum
 
     def repr_failure(self, excinfo, style=None):
+        metric = "ungzip_md5sum" if self.ungzip else "md5sum"
         return (
-            f"Observed md5sum '{self.observed_md5sum}' not equal to expected "
-            f"md5sum '{self.expected_md5sum}' for file '{self.filepath}'"
-        )
+            f"Observed {metric} '{self.observed_md5sum}' not equal to "
+            f"expected {metric} '{self.expected_md5sum}' for file "
+            f"'{self.filepath}'"
+         )

--- a/src/pytest_workflow/file_tests.py
+++ b/src/pytest_workflow/file_tests.py
@@ -137,7 +137,7 @@ class FileMd5(pytest.Item):
         :param workflow: The workflow running to generate the file
         :param ungzip: Whether the file should be ungzipped before calculating
         """
-        name = "unzip_md5sum" if ungzip else "md5sum"
+        name = "ungzip_md5sum" if ungzip else "md5sum"
         super().__init__(name, parent)
         self.filepath = filepath
         self.expected_md5sum = md5sum

--- a/src/pytest_workflow/schema.py
+++ b/src/pytest_workflow/schema.py
@@ -136,7 +136,7 @@ class FileTest(ContentTest):
         A container object
         :param path: the path to the file
         :param md5sum: md5sum of the file contents
-        :param unzip_md5sum: md5sum of the unzipped file contents
+        :param ungzip_md5sum: md5sum of the unzipped file contents
         :param should_exist: whether the file should exist or not
         :param contains: a list of strings that should be present in the file
         :param must_not_contain: a list of strings that should not be present

--- a/src/pytest_workflow/schema.py
+++ b/src/pytest_workflow/schema.py
@@ -125,7 +125,7 @@ class ContentTest(object):
 class FileTest(ContentTest):
     """A class that contains all the properties of a to be tested file."""
     def __init__(self, path: str, md5sum: Optional[str] = None,
-                 ungzip_md5sum: Optional[str] = None,
+                 extract_md5sum: Optional[str] = None,
                  should_exist: bool = DEFAULT_FILE_SHOULD_EXIST,
                  contains: Optional[List[str]] = None,
                  must_not_contain: Optional[List[str]] = None,
@@ -136,7 +136,7 @@ class FileTest(ContentTest):
         A container object
         :param path: the path to the file
         :param md5sum: md5sum of the file contents
-        :param ungzip_md5sum: md5sum of the unzipped file contents
+        :param extract_md5sum: md5sum of the extracted file contents
         :param should_exist: whether the file should exist or not
         :param contains: a list of strings that should be present in the file
         :param must_not_contain: a list of strings that should not be present
@@ -152,7 +152,7 @@ class FileTest(ContentTest):
                          encoding=encoding)
         self.path = Path(path)
         self.md5sum = md5sum
-        self.ungzip_md5sum = ungzip_md5sum
+        self.extract_md5sum = extract_md5sum
         self.should_exist = should_exist
 
 

--- a/src/pytest_workflow/schema.py
+++ b/src/pytest_workflow/schema.py
@@ -125,6 +125,7 @@ class ContentTest(object):
 class FileTest(ContentTest):
     """A class that contains all the properties of a to be tested file."""
     def __init__(self, path: str, md5sum: Optional[str] = None,
+                 ungzip_md5sum: Optional[str] = None,
                  should_exist: bool = DEFAULT_FILE_SHOULD_EXIST,
                  contains: Optional[List[str]] = None,
                  must_not_contain: Optional[List[str]] = None,
@@ -135,6 +136,7 @@ class FileTest(ContentTest):
         A container object
         :param path: the path to the file
         :param md5sum: md5sum of the file contents
+        :param unzip_md5sum: md5sum of the unzipped file contents
         :param should_exist: whether the file should exist or not
         :param contains: a list of strings that should be present in the file
         :param must_not_contain: a list of strings that should not be present
@@ -150,6 +152,7 @@ class FileTest(ContentTest):
                          encoding=encoding)
         self.path = Path(path)
         self.md5sum = md5sum
+        self.ungzip_md5sum = ungzip_md5sum
         self.should_exist = should_exist
 
 

--- a/src/pytest_workflow/schema/schema.json
+++ b/src/pytest_workflow/schema/schema.json
@@ -123,6 +123,10 @@
             "should_exist": {
               "type": "boolean"
             },
+            "ungzip_md5sum": {
+              "type": "string",
+              "pattern": "^[a-f0-9]{32}$"
+            },
             "contains": {
               "type": "array",
               "items": {

--- a/src/pytest_workflow/schema/schema.json
+++ b/src/pytest_workflow/schema/schema.json
@@ -123,7 +123,7 @@
             "should_exist": {
               "type": "boolean"
             },
-            "ungzip_md5sum": {
+            "extract_md5sum": {
               "type": "string",
               "pattern": "^[a-f0-9]{32}$"
             },

--- a/src/pytest_workflow/util.py
+++ b/src/pytest_workflow/util.py
@@ -1,5 +1,4 @@
 import functools
-import gzip
 import hashlib
 import os
 import re
@@ -10,6 +9,8 @@ import warnings
 from pathlib import Path
 from typing import Callable, IO, Iterator, List, Optional, Set, Tuple, Union, \
                    cast
+
+from xopen import xopen
 
 Filepath = Union[str, os.PathLike]
 
@@ -210,15 +211,15 @@ def file_md5sum(filepath: Path, block_size=64 * 1024) -> str:
         return file_handle_md5sum(file_handler, block_size)
 
 
-def gzip_md5sum(filepath: Path, block_size=64 * 1024) -> str:
+def extract_md5sum(filepath: Path, block_size=64 * 1024) -> str:
     """
-    Generates a md5sum for the uncompressed contents of gzipped file.
+    Generates a md5sum for the uncompressed contents of compressed file.
     Reads file in blocks to save memory.
-    :param filepath: a pathlib. Path to the gzipped file
+    :param filepath: a pathlib. Path to the compressed file
     :param block_size: Block size in bytes
     :return: a md5sum as hexadecimal string.
     """
-    with gzip.open(filepath) as file_handler:  # Read the file in bytes
+    with xopen(filepath, 'rb') as file_handler:  # Read the file in bytes
         return file_handle_md5sum(cast(IO[bytes], file_handler), block_size)
 
 

--- a/src/pytest_workflow/util.py
+++ b/src/pytest_workflow/util.py
@@ -1,4 +1,5 @@
 import functools
+import gzip
 import hashlib
 import os
 import re
@@ -7,7 +8,7 @@ import subprocess
 import sys
 import warnings
 from pathlib import Path
-from typing import Callable, Iterator, List, Optional, Set, Tuple, Union
+from typing import BinaryIO, Callable, Iterator, List, Optional, Set, Tuple, Union
 
 Filepath = Union[str, os.PathLike]
 
@@ -204,10 +205,32 @@ def file_md5sum(filepath: Path, block_size=64 * 1024) -> str:
     :param block_size: Block size in bytes
     :return: a md5sum as hexadecimal string.
     """
-    hasher = hashlib.md5()
     with filepath.open('rb') as file_handler:  # Read the file in bytes
-        for block in iter(lambda: file_handler.read(block_size), b''):
-            hasher.update(block)
+        return file_handle_md5sum(file_handler, block_size)
+
+
+def gzip_md5sum(filepath: Path, block_size=64 * 1024) -> str:
+    """
+    Generates a md5sum for the uncompressed contents of gzipped file.
+    Reads file in blocks to save memory.
+    :param filepath: a pathlib. Path to the gzipped file
+    :param block_size: Block size in bytes
+    :return: a md5sum as hexadecimal string.
+    """
+    with gzip.open(filepath) as file_handler:  # Read the file in bytes
+        return file_handle_md5sum(file_handler, block_size)
+
+
+def file_handle_md5sum(file_handler: BinaryIO, block_size) -> str:
+    """
+    Generates a md5sum for a file handle. Reads file in blocks to save memory.
+    :param file_handler: a readable binary file handler
+    :param block_size: Block size in bytes
+    :return: a md5sum as hexadecimal string.
+    """
+    hasher = hashlib.md5()
+    for block in iter(lambda: file_handler.read(block_size), b''):
+        hasher.update(block)
     return hasher.hexdigest()
 
 

--- a/src/pytest_workflow/util.py
+++ b/src/pytest_workflow/util.py
@@ -8,7 +8,8 @@ import subprocess
 import sys
 import warnings
 from pathlib import Path
-from typing import BinaryIO, Callable, Iterator, List, Optional, Set, Tuple, Union
+from typing import Callable, IO, Iterator, List, Optional, Set, Tuple, Union, \
+                   cast
 
 Filepath = Union[str, os.PathLike]
 
@@ -218,10 +219,10 @@ def gzip_md5sum(filepath: Path, block_size=64 * 1024) -> str:
     :return: a md5sum as hexadecimal string.
     """
     with gzip.open(filepath) as file_handler:  # Read the file in bytes
-        return file_handle_md5sum(file_handler, block_size)
+        return file_handle_md5sum(cast(IO[bytes], file_handler), block_size)
 
 
-def file_handle_md5sum(file_handler: BinaryIO, block_size) -> str:
+def file_handle_md5sum(file_handler: IO[bytes], block_size) -> str:
     """
     Generates a md5sum for a file handle. Reads file in blocks to save memory.
     :param file_handler: a readable binary file handler

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -171,7 +171,7 @@ def test_filetest_defaults():
     assert file_test.contains_regex == []
     assert file_test.must_not_contain_regex == []
     assert file_test.md5sum is None
-    assert file_test.ungzip_md5sum is None
+    assert file_test.extract_md5sum is None
     assert file_test.should_exist
 
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -171,6 +171,7 @@ def test_filetest_defaults():
     assert file_test.contains_regex == []
     assert file_test.must_not_contain_regex == []
     assert file_test.md5sum is None
+    assert file_test.ungzip_md5sum is None
     assert file_test.should_exist
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -26,8 +26,8 @@ from pathlib import Path
 import pytest
 
 from pytest_workflow.util import decode_unaligned, duplicate_tree, \
-    file_md5sum, git_check_submodules_cloned, git_root, \
-    gzip_md5sum, is_in_dir, link_tree, replace_whitespace
+    extract_md5sum, file_md5sum, git_check_submodules_cloned, git_root, \
+    is_in_dir, link_tree, replace_whitespace
 
 WHITESPACE_TESTS = [
     ("bla\nbla", "bla_bla"),
@@ -164,11 +164,11 @@ def test_file_md5sum(hash_file: Path):
     assert whole_file_md5 == per_line_md5
 
 
-def test_gzip_md5sum():
+def test_extract_md5sum():
     hash_file = HASH_FILE_DIR / "LICENSE.gz"
     with gzip.open(hash_file, "rb") as contents_fh:
         whole_file_md5 = hashlib.md5(contents_fh.read()).hexdigest()
-    per_line_md5 = gzip_md5sum(hash_file)
+    per_line_md5 = extract_md5sum(hash_file)
     assert whole_file_md5 == per_line_md5
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -13,6 +13,7 @@
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with pytest-workflow.  If not, see <https://www.gnu.org/licenses/
+import gzip
 import hashlib
 import itertools
 import os
@@ -26,7 +27,7 @@ import pytest
 
 from pytest_workflow.util import decode_unaligned, duplicate_tree, \
     file_md5sum, git_check_submodules_cloned, git_root, \
-    is_in_dir, link_tree, replace_whitespace
+    gzip_md5sum, is_in_dir, link_tree, replace_whitespace
 
 WHITESPACE_TESTS = [
     ("bla\nbla", "bla_bla"),
@@ -160,6 +161,14 @@ HASH_FILE_DIR = Path(__file__).parent / "hash_files"
 def test_file_md5sum(hash_file: Path):
     whole_file_md5 = hashlib.md5(hash_file.read_bytes()).hexdigest()
     per_line_md5 = file_md5sum(hash_file)
+    assert whole_file_md5 == per_line_md5
+
+
+def test_gzip_md5sum():
+    hash_file = HASH_FILE_DIR / "LICENSE.gz"
+    with gzip.open(hash_file, "rb") as contents_fh:
+        whole_file_md5 = hashlib.md5(contents_fh.read()).hexdigest()
+    per_line_md5 = gzip_md5sum(hash_file)
     assert whole_file_md5 == per_line_md5
 
 


### PR DESCRIPTION
### Checklist
- [x] Pull request details were added to HISTORY.rst

I frequently have workflows that generate *.fastq.gz files as outputs. Because gzip embeds a timestamp in the file, md5sum comparisons fail. `gzip` with `-n` can be used to omit the timestamp, but the gzipping is often part of third-party tool and not configurable. This PR adds a `ungzip_md5sum` option that runs md5sum on the ungzipped contents of the file.