### PR TITLE
Respect pytest `-s` flag, streaming stdout/stderr as the test runs

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,6 +8,10 @@ Changelog
 .. This document is user facing. Please word the changes in such a way
 .. that users understand how the changes affect the new version.
 
+unreleased
+---------------------------
++ ``-s`` pytest flag is now supported, streaming stdout/stderr as the tests run
+
 version 2.1.0
 ---------------------------
 + Python version 3.7 support is dropped because it is deprecated. Python

--- a/src/pytest_workflow/content_tests.py
+++ b/src/pytest_workflow/content_tests.py
@@ -202,8 +202,8 @@ class ContentTestItem(pytest.Item):
         self.parent: ContentTestCollector = parent  # explicitly declare type
         assert self.parent.filepath is not None, (
             f"Invalid test {content_name}, unknown file to validate. "
-            "This can happen if you specify stdout/stderr tests while specifying a "
-            "different capture method.")
+            "This can happen if you specify stdout/stderr tests while "
+            "specifying a different capture method.")
         self.should_contain = should_contain
         self.string = string
         self.content_name = content_name

--- a/src/pytest_workflow/plugin.py
+++ b/src/pytest_workflow/plugin.py
@@ -463,20 +463,19 @@ class WorkflowTestsCollector(pytest.Collector):
                 parent=self, filetest=filetest, workflow=workflow)
             for filetest in self.workflow_test.files]
 
-        if self.config.getoption("capture") != "no":
-            tests += [ContentTestCollector.from_parent(
-                name="stdout", parent=self,
-                filepath=workflow.stdout_file,
-                content_test=self.workflow_test.stdout,
-                workflow=workflow,
-                content_name=f"'{self.workflow_test.name}': stdout")]
+        tests += [ContentTestCollector.from_parent(
+            name="stdout", parent=self,
+            filepath=workflow.stdout_file,
+            content_test=self.workflow_test.stdout,
+            workflow=workflow,
+            content_name=f"'{self.workflow_test.name}': stdout")]
 
-            tests += [ContentTestCollector.from_parent(
-                name="stderr", parent=self,
-                filepath=workflow.stderr_file,
-                content_test=self.workflow_test.stderr,
-                workflow=workflow,
-                content_name=f"'{self.workflow_test.name}': stderr")]
+        tests += [ContentTestCollector.from_parent(
+            name="stderr", parent=self,
+            filepath=workflow.stderr_file,
+            content_test=self.workflow_test.stderr,
+            workflow=workflow,
+            content_name=f"'{self.workflow_test.name}': stderr")]
 
         return tests
 

--- a/src/pytest_workflow/plugin.py
+++ b/src/pytest_workflow/plugin.py
@@ -409,7 +409,8 @@ class WorkflowTestsCollector(pytest.Collector):
         workflow = Workflow(command=self.workflow_test.command,
                             cwd=tempdir,
                             name=self.workflow_test.name,
-                            desired_exit_code=self.workflow_test.exit_code)
+                            desired_exit_code=self.workflow_test.exit_code,
+                            capture=self.config.getoption("capture"))
 
         # Add the workflow to the workflow queue.
         self.config.workflow_queue.put(workflow)
@@ -462,19 +463,20 @@ class WorkflowTestsCollector(pytest.Collector):
                 parent=self, filetest=filetest, workflow=workflow)
             for filetest in self.workflow_test.files]
 
-        tests += [ContentTestCollector.from_parent(
-            name="stdout", parent=self,
-            filepath=workflow.stdout_file,
-            content_test=self.workflow_test.stdout,
-            workflow=workflow,
-            content_name=f"'{self.workflow_test.name}': stdout")]
+        if self.config.getoption("capture") != "no":
+            tests += [ContentTestCollector.from_parent(
+                name="stdout", parent=self,
+                filepath=workflow.stdout_file,
+                content_test=self.workflow_test.stdout,
+                workflow=workflow,
+                content_name=f"'{self.workflow_test.name}': stdout")]
 
-        tests += [ContentTestCollector.from_parent(
-            name="stderr", parent=self,
-            filepath=workflow.stderr_file,
-            content_test=self.workflow_test.stderr,
-            workflow=workflow,
-            content_name=f"'{self.workflow_test.name}': stderr")]
+            tests += [ContentTestCollector.from_parent(
+                name="stderr", parent=self,
+                filepath=workflow.stderr_file,
+                content_test=self.workflow_test.stderr,
+                workflow=workflow,
+                content_name=f"'{self.workflow_test.name}': stderr")]
 
         return tests
 

--- a/src/pytest_workflow/workflow.py
+++ b/src/pytest_workflow/workflow.py
@@ -65,8 +65,9 @@ class Workflow(object):
         # to prevent clutter created when testing.
         supported_capture_methods = ["no", "fd"]
         if capture not in supported_capture_methods:
-            raise ValueError(f"only capture methods {supported_capture_methods} are "
-                             f"supported, found {capture}")
+            raise ValueError("only capture methods "
+                             f"{supported_capture_methods} are supported, "
+                             f"found {capture}")
         self.capture = capture
         self.stdout_file = None
         self.stderr_file = None
@@ -169,7 +170,9 @@ class Workflow(object):
     def stdout(self) -> bytes:
         self.wait()
         if self.stdout_file is None:
-            raise ValueError(f"Stdout not available with capture={self.capture}")
+            raise ValueError(
+                f"Stdout not available with capture={self.capture}"
+            )
         with self.stdout_file.open('rb') as stdout:
             return stdout.read()
 
@@ -177,7 +180,9 @@ class Workflow(object):
     def stderr(self) -> bytes:
         self.wait()
         if self.stderr_file is None:
-            raise ValueError(f"Stdout not available with capture={self.capture}")
+            raise ValueError(
+                f"Stdout not available with capture={self.capture}"
+            )
         with self.stderr_file.open('rb') as stderr:
             return stderr.read()
 

--- a/tests/test_fail_messages.py
+++ b/tests/test_fail_messages.py
@@ -179,3 +179,16 @@ def test_messages_exitcode(test: str, message: str, pytester):
     # possible due to multiple levels of process launching.
     result = pytester.runpytest("-v", "--sb", "5")
     assert message in result.stdout.str()
+
+
+def test_invalid_test_capture(pytester):
+    test_yml_contents = """\
+    - name: tee test
+      command: bash -c "echo foo"
+      stdout:
+        contains:
+          - foo
+    """
+    pytester.makefile(".yml", textwrap.dedent(test_yml_contents))
+    result = pytester.runpytest("-v", "-s")
+    assert "Invalid test 'tee test': stdout, unknown file to validate" in result.stdout.str()

--- a/tests/test_fail_messages.py
+++ b/tests/test_fail_messages.py
@@ -191,4 +191,7 @@ def test_invalid_test_capture(pytester):
     """
     pytester.makefile(".yml", textwrap.dedent(test_yml_contents))
     result = pytester.runpytest("-v", "-s")
-    assert "Invalid test 'tee test': stdout, unknown file to validate" in result.stdout.str()
+    assert (
+        "Invalid test 'tee test': stdout, unknown file to validate"
+        in result.stdout.str()
+    )

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -105,3 +105,15 @@ def test_workflow_matching_exit_code():
     workflow2 = Workflow("grep", desired_exit_code=2)
     workflow2.run()
     assert workflow2.matching_exitcode()
+
+def test_capture_unsupported():
+    with pytest.raises(ValueError) as error:
+        workflow = Workflow("echo moo", capture="tee-sys")
+    error.match("only capture methods")
+
+def test_capture_no():
+    workflow = Workflow("echo moo", capture="no")
+    workflow.run()
+    with pytest.raises(ValueError) as error:
+        workflow.stdout
+    error.match("Stdout not available")

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -106,10 +106,12 @@ def test_workflow_matching_exit_code():
     workflow2.run()
     assert workflow2.matching_exitcode()
 
+
 def test_capture_unsupported():
     with pytest.raises(ValueError) as error:
-        workflow = Workflow("echo moo", capture="tee-sys")
+        Workflow("echo moo", capture="tee-sys")
     error.match("only capture methods")
+
 
 def test_capture_no():
     workflow = Workflow("echo moo", capture="no")


### PR DESCRIPTION
### Checklist
- [x] Pull request details were added to HISTORY.rst

I took a crack at https://github.com/LUMC/pytest-workflow/issues/199

Doing some research, it seems pytest already has a setting to dictate how to handle stdout/stderr: https://docs.pytest.org/en/latest/how-to/capture-stdout-stderr.html#setting-capturing-methods-or-disabling-capturing

I added support for `-s` (which sets `capture=no`). It bypasses capturing stdout/stderr, streaming them to the terminal in real-time. I did not attempt to implement the other options because they're more complex - capturing and streaming output simultaneously might require a multithreaded implementation. I couldn't find a great way to support it.

Note that this is incompatible with `stdout:` and `stderr:` tests (as there is no captured stdout/stderr to check). I wasn't sure where the best place to catch this incompatibility was.

At first, I de-registered the `stdout` and `stderr` `ContentTestCollector` altogether when `-s` is specified. But this just silently drops those tests - no good.

Then I moved to validating at test runtime in [`runtest`](https://github.com/LUMC/pytest-workflow/blob/8e23a1ef75057600f06ebe543afc4b3b1ad551b3/src/pytest_workflow/content_tests.py#L203). But `ContentTestItem` [specifies a `repr_failure`](https://github.com/LUMC/pytest-workflow/blob/8e23a1ef75057600f06ebe543afc4b3b1ad551b3/src/pytest_workflow/content_tests.py#L226) message which didn't really describe this failure mode.

So then I moved to validating in the per-test-item constructor. This does work. I'm not sure if it's the best place.

I tried to add some tests to make sure this functions as expected. I also used variants of the following yaml to manually test:

```yaml
- name: tee test
  command: bash -c "echo foo | tee test.file && sleep 3"
  files:
    - path: test.file
      contains:
        - foo
        - bar
  stdout:
    contains:
      - bar
```

Let me know if you think there's a better way to implement this.